### PR TITLE
chore(cd): update orca-armory version to 2021.4.23.2.28.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,12 +14,12 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:889cd0c99e78c194835507cdda9647bbd2f5821da964a999a78f2c78c1ea10cc
+      imageId: sha256:1b6ce860a501cf5bbea73321f4bdba1cc8aa656bf874ac5236e5b685637f65f0
       repository: armory/orca-armory
-      tag: 2021.4.19.16.16.47.master
+      tag: 2021.4.23.2.28.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 61c26abcd0ae59702f8af551e3515e79b4a10009
+      sha: 2dd9233ce1fb64ef1c4768b574f7146bee542333


### PR DESCRIPTION
Event
```
{
  "service": {
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:1b6ce860a501cf5bbea73321f4bdba1cc8aa656bf874ac5236e5b685637f65f0",
        "repository": "armory/orca-armory",
        "tag": "2021.4.23.2.28.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "2dd9233ce1fb64ef1c4768b574f7146bee542333"
      }
    },
    "name": "orca-armory"
  }
}
```