### PR TITLE
chore(cd): update orca-armory version to 2021.4.23.20.50.9.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,12 +14,12 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:889cd0c99e78c194835507cdda9647bbd2f5821da964a999a78f2c78c1ea10cc
+      imageId: sha256:a8447f7d53c931c1f9b421f0002528419521dbbfbbb954a0635e8fd0aef6175f
       repository: armory/orca-armory
-      tag: 2021.4.19.16.16.47.master
+      tag: 2021.4.23.20.50.9.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 61c26abcd0ae59702f8af551e3515e79b4a10009
+      sha: 350f2e77474604fccd35855a76a04e3e1ea9ed0e


### PR DESCRIPTION
Event
```
{
  "service": {
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a8447f7d53c931c1f9b421f0002528419521dbbfbbb954a0635e8fd0aef6175f",
        "repository": "armory/orca-armory",
        "tag": "2021.4.23.20.50.9.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "350f2e77474604fccd35855a76a04e3e1ea9ed0e"
      }
    },
    "name": "orca-armory"
  }
}
```