### PR TITLE
chore(cd): update orca-armory version to 2021.05.07.14.59.27.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:dbebf033776da6e8c696cd2bd0000bea5be1c0667a17787fcbb6625485c47f1c
+      imageId: sha256:78fe78d2f29be508332ec04ab3d16fd51dc146f18effd803494a1a220a7b0f84
       repository: armory/orca-armory
-      tag: 2021.05.06.21.37.58.master
+      tag: 2021.05.07.14.59.27.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: bf894a96d16cf59aeff738b28efd42c5d64ca63e
+      sha: 3178bf821a30fa6879e58896cc50aec0cb577f47


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:78fe78d2f29be508332ec04ab3d16fd51dc146f18effd803494a1a220a7b0f84",
        "repository": "armory/orca-armory",
        "tag": "2021.05.07.14.59.27.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "3178bf821a30fa6879e58896cc50aec0cb577f47"
      }
    },
    "name": "orca-armory"
  }
}
```