### PR TITLE
chore(cd): update orca-armory version to 2021.05.13.19.32.21.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:dbebf033776da6e8c696cd2bd0000bea5be1c0667a17787fcbb6625485c47f1c
+      imageId: sha256:15707b3199794fa6c697bf255244567c591d8b5b52fd659bdb794f9703c1b733
       repository: armory/orca-armory
-      tag: 2021.05.06.21.37.58.master
+      tag: 2021.05.13.19.32.21.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: bf894a96d16cf59aeff738b28efd42c5d64ca63e
+      sha: 288e052fdc3706d1e6888056a9c142a707b5c032


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:15707b3199794fa6c697bf255244567c591d8b5b52fd659bdb794f9703c1b733",
        "repository": "armory/orca-armory",
        "tag": "2021.05.13.19.32.21.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "288e052fdc3706d1e6888056a9c142a707b5c032"
      }
    },
    "name": "orca-armory"
  }
}
```