### PR TITLE
chore(cd): update orca-armory version to 2021.05.26.06.59.12.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -11,30 +11,6 @@ services:
         repoName: clouddriver-armory
         type: github
       sha: fdd673416cab6c29051c39fecb31a5edeba58f48
-  kayenta-armory:
-    baseService: kayenta
-    image:
-      imageId: sha256:7c4b011c9197e33d94a824a0bec96b8d9592562469f617e29a2ea9f34d7ad853
-      repository: armory/kayenta-armory
-      tag: 2021.05.25.19.19.39.master
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: kayenta-armory
-        type: github
-      sha: a9c1d485273eea0f2fee2493d533275cde9e0835
-  igor-armory:
-    baseService: igor
-    image:
-      imageId: sha256:810af75d04fee1d395e025c40cdd02691ba26d7ab2d929d4735fc3e366064537
-      repository: armory/igor-armory
-      tag: 2021.05.21.17.41.40.master
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: igor-armory
-        type: github
-      sha: 3f5dab2837cb0996776ffa61d45af2ad21eac3cb
   fiat-armory:
     baseService: fiat
     image:
@@ -47,15 +23,39 @@ services:
         repoName: fiat-armory
         type: github
       sha: 243a54f745e00435f302dd216e3bd3b72bc93779
+  igor-armory:
+    baseService: igor
+    image:
+      imageId: sha256:810af75d04fee1d395e025c40cdd02691ba26d7ab2d929d4735fc3e366064537
+      repository: armory/igor-armory
+      tag: 2021.05.21.17.41.40.master
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: igor-armory
+        type: github
+      sha: 3f5dab2837cb0996776ffa61d45af2ad21eac3cb
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:7c4b011c9197e33d94a824a0bec96b8d9592562469f617e29a2ea9f34d7ad853
+      repository: armory/kayenta-armory
+      tag: 2021.05.25.19.19.39.master
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: a9c1d485273eea0f2fee2493d533275cde9e0835
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0978cf79e57c7aa4bd6b00665a6c140d858e50d7f983dee1f4a25cfec8255bf8
+      imageId: sha256:9dd19100056dd70798d1906fc22c6d8a11b7ece70a26116cdc29525ad73e08e6
       repository: armory/orca-armory
-      tag: 2021.05.25.13.29.47.master
+      tag: 2021.05.26.06.59.12.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: d1ff6284cdf7f5d15e5c592a25aa64fadc8904d4
+      sha: 198d7770c9cf511ccc301543e91b2e7abb8bb711


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:9dd19100056dd70798d1906fc22c6d8a11b7ece70a26116cdc29525ad73e08e6",
        "repository": "armory/orca-armory",
        "tag": "2021.05.26.06.59.12.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "198d7770c9cf511ccc301543e91b2e7abb8bb711"
      }
    },
    "name": "orca-armory"
  }
}
```