### PR TITLE
chore(cd): update orca-armory version to 2021.06.01.19.12.07.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,12 +2,12 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:dbebf033776da6e8c696cd2bd0000bea5be1c0667a17787fcbb6625485c47f1c
+      imageId: sha256:59267b7f484510122814bb76792293df776aac47b4ce1a06b40ca2b5e8145046
       repository: armory/orca-armory
-      tag: 2021.05.06.21.37.58.master
+      tag: 2021.06.01.19.12.07.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: bf894a96d16cf59aeff738b28efd42c5d64ca63e
+      sha: 4044b8996dd6c9138d40874d36fb07d954a08320


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:59267b7f484510122814bb76792293df776aac47b4ce1a06b40ca2b5e8145046",
        "repository": "armory/orca-armory",
        "tag": "2021.06.01.19.12.07.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "4044b8996dd6c9138d40874d36fb07d954a08320"
      }
    },
    "name": "orca-armory"
  }
}
```