### PR TITLE
chore(cd): update fiat-armory version to 2021.06.08.20.06.10.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,4 +1,16 @@
 services:
+  fiat-armory:
+    baseService: fiat
+    image:
+      imageId: sha256:dfd07b3ad41329357977f984073bbc316ec528f0bdd40153867c3bdeb0f6c704
+      repository: armory/fiat-armory
+      tag: 2021.06.08.20.06.10.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: fiat-armory
+        type: github
+      sha: db352ce843544c46a6c39aaabbf3998be22dd362
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:dfd07b3ad41329357977f984073bbc316ec528f0bdd40153867c3bdeb0f6c704",
        "repository": "armory/fiat-armory",
        "tag": "2021.06.08.20.06.10.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "db352ce843544c46a6c39aaabbf3998be22dd362"
      }
    },
    "name": "fiat-armory"
  }
}
```