### PR TITLE
chore(cd): update deck-armory version to 2021.06.08.21.38.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -11,6 +11,18 @@ services:
         repoName: clouddriver-armory
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
+  deck-armory:
+    baseService: null
+    image:
+      imageId: sha256:d2264e07d1abc87ca56c785ae0b65860c106e36ad3657f9acb000ae487140541
+      repository: armory/deck-armory
+      tag: 2021.06.08.21.38.54.master
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: deck-armory
+        type: github
+      sha: 1f053f8d702b85e0ffab40178d159342363f7896
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:d2264e07d1abc87ca56c785ae0b65860c106e36ad3657f9acb000ae487140541",
        "repository": "armory/deck-armory",
        "tag": "2021.06.08.21.38.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1f053f8d702b85e0ffab40178d159342363f7896"
      }
    },
    "name": "deck-armory"
  }
}
```