### PR TITLE
chore(cd): update rosco-armory version to 2021.06.08.22.01.40.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,7 +12,7 @@ services:
         type: github
       sha: 4044b8996dd6c9138d40874d36fb07d954a08320
   rosco-armory:
-    baseService: null
+    baseService: rosco
     image:
       imageId: sha256:f0e468dc44e55a63a63fd8513c92ff7f7cd1a879beb7af630875e8a9bc7aaeb2
       repository: armory/rosco-armory


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:f0e468dc44e55a63a63fd8513c92ff7f7cd1a879beb7af630875e8a9bc7aaeb2",
        "repository": "armory/rosco-armory",
        "tag": "2021.06.08.22.01.40.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "33f13972e80cbe1d83512e64ba4f076ebf27e061"
      }
    },
    "name": "rosco-armory"
  }
}
```