### PR TITLE
chore(cd): update gate-armory version to 2021.06.10.17.59.20.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -24,17 +24,17 @@ services:
         type: github
       sha: 3bc55ff468b8df4390c0506ec24722084973b0fe
   gate-armory:
-    baseService: gate
+    baseService: gate-bom
     image:
-      imageId: sha256:4438607d106a8412217319541c6d7fa8de1aa0d9f8c3887711bb5514569417b4
+      imageId: sha256:48efd9ec59e3e62311b4c89f065ff236859a611c58492b8c712d6b2b5e16418b
       repository: armory/gate-armory
-      tag: 2021.06.02.20.36.40.master
+      tag: 2021.06.10.17.59.20.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 13089d8ca9d44f053b90b92c1603bc467fc9bc2f
+      sha: d10b9dfb1da6b025e268fa92b53653c29b018ba8
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "gate-bom",
      "image": {
        "imageId": "sha256:48efd9ec59e3e62311b4c89f065ff236859a611c58492b8c712d6b2b5e16418b",
        "repository": "armory/gate-armory",
        "tag": "2021.06.10.17.59.20.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "d10b9dfb1da6b025e268fa92b53653c29b018ba8"
      }
    },
    "name": "gate-armory"
  }
}
```