### PR TITLE
chore(cd): update echo-armory version to 2021.06.01.19.01.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -11,6 +11,18 @@ services:
         repoName: clouddriver-armory
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
+  echo-armory:
+    baseService: echo-bom
+    image:
+      imageId: sha256:05900f071b868b4c0fe6e052f871ef125b1c2deee7b892ff62b99b410449657b
+      repository: armory/echo-armory
+      tag: 2021.06.01.19.01.58.master
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: echo-armory
+        type: github
+      sha: 8f4f7c8d37c5fddbf844691b3312daaf3c89a7cf
   fiat-armory:
     baseService: fiat
     image:

--- a/stack.yml
+++ b/stack.yml
@@ -12,7 +12,7 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   echo-armory:
-    baseService: echo-bom
+    baseService: echo
     image:
       imageId: sha256:05900f071b868b4c0fe6e052f871ef125b1c2deee7b892ff62b99b410449657b
       repository: armory/echo-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "echo-bom",
      "image": {
        "imageId": "sha256:05900f071b868b4c0fe6e052f871ef125b1c2deee7b892ff62b99b410449657b",
        "repository": "armory/echo-armory",
        "tag": "2021.06.01.19.01.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "8f4f7c8d37c5fddbf844691b3312daaf3c89a7cf"
      }
    },
    "name": "echo-armory"
  }
}
```