### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.02.28.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,7 +12,7 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: null
+    baseService: deck
     image:
       imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
       repository: armory/deck-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.02.28.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f56ba2fe03240439cd16d58c9f1dd6b635a87953"
      }
    },
    "name": "deck-armory"
  }
}
```