### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.17.48.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:bbb838afe2ab6b1b382d6a96f8669e2d812628615e6ab9cb07713394d42160f6
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.17.48.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: c8ef794cf9420616e483f240d6881a2cbab02e49
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:bbb838afe2ab6b1b382d6a96f8669e2d812628615e6ab9cb07713394d42160f6",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.17.48.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "c8ef794cf9420616e483f240d6881a2cbab02e49"
      }
    },
    "name": "deck-armory"
  }
}
```