### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.17.58.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:b812ba3663d2c489c4856a4ecdab556f7871790c9cd7a5f543f0a62e3f1272e3
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.17.58.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: 3d66ebfdb1e627aa7b8879f872460eeef36ea245
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:b812ba3663d2c489c4856a4ecdab556f7871790c9cd7a5f543f0a62e3f1272e3",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.17.58.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "3d66ebfdb1e627aa7b8879f872460eeef36ea245"
      }
    },
    "name": "deck-armory"
  }
}
```