### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.18.30.27.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:a3585b85acf55c6c475c246dd3b65c6c59407d2f9ce5295e28a587310813192a
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.18.30.27.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: e7eb66c0a2153389e60223559be347c3dfc307eb
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:a3585b85acf55c6c475c246dd3b65c6c59407d2f9ce5295e28a587310813192a",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.18.30.27.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e7eb66c0a2153389e60223559be347c3dfc307eb"
      }
    },
    "name": "deck-armory"
  }
}
```