### PR TITLE
chore(cd): update front50-armory version to 2021.06.08.21.03.20.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -47,6 +47,18 @@ services:
         repoName: fiat-armory
         type: github
       sha: 3bc55ff468b8df4390c0506ec24722084973b0fe
+  front50-armory:
+    baseService: front50
+    image:
+      imageId: sha256:f8775f9bbfd08f05c0ecf40af088c77e955a75d1ff679a7c7ed7c929fe5a6b9b
+      repository: armory/front50-armory
+      tag: 2021.06.08.21.03.20.master
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: front50-armory
+        type: github
+      sha: 29d5ddd231905c1a280a081cb55632b870d8c65f
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:f8775f9bbfd08f05c0ecf40af088c77e955a75d1ff679a7c7ed7c929fe5a6b9b",
        "repository": "armory/front50-armory",
        "tag": "2021.06.08.21.03.20.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "29d5ddd231905c1a280a081cb55632b870d8c65f"
      }
    },
    "name": "front50-armory"
  }
}
```