### PR TITLE
chore(cd): update kayenta-armory version to 2021.06.11.20.21.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:3be587b7916ddd2b257087a4080c960a6780daaabf17382f1ca93eee5a75ea81
+      imageId: sha256:1a430bb211159de8cd7aa7a51d4a091d06b74f2dcff4bfd9092788bc6c79ddee
       repository: armory/kayenta-armory
-      tag: 2021.05.27.21.41.13.master
+      tag: 2021.06.11.20.21.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 5d965ccff3cc5f66f091240ad4b74f4bc2c75e45
+      sha: af0e44157f87204c47830833fc46c15fe1ff586e
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:1a430bb211159de8cd7aa7a51d4a091d06b74f2dcff4bfd9092788bc6c79ddee",
        "repository": "armory/kayenta-armory",
        "tag": "2021.06.11.20.21.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "af0e44157f87204c47830833fc46c15fe1ff586e"
      }
    },
    "name": "kayenta-armory"
  }
}
```