### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.20.38.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:d6e72e63a53443fc7b06efb440c57041e94c95b0dcc64cccd8c80b248a0e5b58
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.20.38.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: d17e76c5e148ed46a55f4a0390ad5d9c31db1493
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:d6e72e63a53443fc7b06efb440c57041e94c95b0dcc64cccd8c80b248a0e5b58",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.20.38.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "d17e76c5e148ed46a55f4a0390ad5d9c31db1493"
      }
    },
    "name": "deck-armory"
  }
}
```