### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.21.09.25.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:1a1506a5b4341afed2876325bddc55455959b91737e3bbbca99d3d4b067082b7
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.21.09.25.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: 0bfac831bada93abd79e37582b611507089d168e
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:1a1506a5b4341afed2876325bddc55455959b91737e3bbbca99d3d4b067082b7",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.21.09.25.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "0bfac831bada93abd79e37582b611507089d168e"
      }
    },
    "name": "deck-armory"
  }
}
```