### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.21.19.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:9b5f0906b35ae28fc4f3b3bfe1fd312bfc26eac479f49509637cf179e133beae
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.21.19.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: ed51730ab9451f620f294699bbbc099208b0dd2d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:9b5f0906b35ae28fc4f3b3bfe1fd312bfc26eac479f49509637cf179e133beae",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.21.19.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "ed51730ab9451f620f294699bbbc099208b0dd2d"
      }
    },
    "name": "deck-armory"
  }
}
```