### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.22.16.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: da4d922402fc058ea37cad0ee042bc4def0b1cd6
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:fd4fddd3e7822f57ba5406463c078240c8d7debe86c1775dcf02db18288aeec8
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.22.16.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: 42c524dd867f0039259c6fa86525c952fed13fa9
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:fd4fddd3e7822f57ba5406463c078240c8d7debe86c1775dcf02db18288aeec8",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.22.16.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "42c524dd867f0039259c6fa86525c952fed13fa9"
      }
    },
    "name": "deck-armory"
  }
}
```