### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.23.24.07.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: 8ce39c09abb776f0c9c99f90cc1528aa41ef62e2
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:27f8271a34c147bb16643cb7afbbe3cc6ff849d234699509151d737dc050b8cc
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.23.24.07.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: 9efd9957e38162bd215ddcae60afb100ed09736c
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:27f8271a34c147bb16643cb7afbbe3cc6ff849d234699509151d737dc050b8cc",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.23.24.07.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "9efd9957e38162bd215ddcae60afb100ed09736c"
      }
    },
    "name": "deck-armory"
  }
}
```