### PR TITLE
chore(cd): update deck-armory version to 2021.06.11.23.54.22.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,17 +12,17 @@ services:
         type: github
       sha: 8ce39c09abb776f0c9c99f90cc1528aa41ef62e2
   deck-armory:
-    baseService: deck
+    baseService: null
     image:
-      imageId: sha256:b432084e11d73ec965f969f0e49072e2112336fc4d700110e3b7bad81f2bc766
+      imageId: sha256:0e93a9fa8ddec6226a0894354f5009d0e0631000fbf102be0336029fb497177d
       repository: armory/deck-armory
-      tag: 2021.06.11.02.28.21.master
+      tag: 2021.06.11.23.54.22.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: f56ba2fe03240439cd16d58c9f1dd6b635a87953
+      sha: e3169d616f30f7d5858e3d1ad821dc0ed4aebc03
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:0e93a9fa8ddec6226a0894354f5009d0e0631000fbf102be0336029fb497177d",
        "repository": "armory/deck-armory",
        "tag": "2021.06.11.23.54.22.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e3169d616f30f7d5858e3d1ad821dc0ed4aebc03"
      }
    },
    "name": "deck-armory"
  }
}
```