### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.03.31.08.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:375de98c1e0f78daa25024a2ec8f277ffa18c106667fea69e2f4de9d154affdd
+      imageId: sha256:9d1b54f4df691048d531ae59ae8bcfeb4b981f89339c531ceda942e5c2165ba5
       repository: armory/deck-armory
-      tag: 2021.06.14.21.26.35.master
+      tag: 2021.06.15.03.31.08.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: be5a3445eb14459b5e53072a08dcfaed96aab429
+      sha: bb0f23c63ca0b280f9ccf0ff1f170bc24dcd33fb
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:9d1b54f4df691048d531ae59ae8bcfeb4b981f89339c531ceda942e5c2165ba5",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.03.31.08.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "bb0f23c63ca0b280f9ccf0ff1f170bc24dcd33fb"
      }
    },
    "name": "deck-armory"
  }
}
```