### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.04.27.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:9d1b54f4df691048d531ae59ae8bcfeb4b981f89339c531ceda942e5c2165ba5
+      imageId: sha256:96a7d65e71117757208513064257e373c7cfb68575898cd05cbedfe9a613381d
       repository: armory/deck-armory
-      tag: 2021.06.15.03.31.08.master
+      tag: 2021.06.15.04.27.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: bb0f23c63ca0b280f9ccf0ff1f170bc24dcd33fb
+      sha: c35a11628761f81da6ad442a1ca5c0f61fea6e21
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:96a7d65e71117757208513064257e373c7cfb68575898cd05cbedfe9a613381d",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.04.27.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "c35a11628761f81da6ad442a1ca5c0f61fea6e21"
      }
    },
    "name": "deck-armory"
  }
}
```