### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.04.40.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:1f3cdbebd3de9c9e67aaf7234b193a358000fad44e8550649ebe4ba509767fce
+      imageId: sha256:891b98acebc4026f9afc22e98db65a941da84deb5cb3682fec9720fbb5dfbd60
       repository: armory/deck-armory
-      tag: 2021.06.15.04.15.46.master
+      tag: 2021.06.15.04.40.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 70bab14071cb867d44204209ff91a83fdc259455
+      sha: c75a3892bde865898d2199036cae1c821f8fa2cf
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:891b98acebc4026f9afc22e98db65a941da84deb5cb3682fec9720fbb5dfbd60",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.04.40.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "c75a3892bde865898d2199036cae1c821f8fa2cf"
      }
    },
    "name": "deck-armory"
  }
}
```