### PR TITLE
chore(cd): update clouddriver-armory version to 2021.06.15.15.50.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:d373651e304524fa04ef7149472288636e9db149dae6f1dc8ea3ff4191761fe7
+      imageId: sha256:3db042b7c381a49cf993065b940f0104023d911f1580ca3fc506a12b1c1623d1
       repository: armory/clouddriver-armory
-      tag: 2021.06.11.20.11.24.master
+      tag: 2021.06.15.15.50.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8ce39c09abb776f0c9c99f90cc1528aa41ef62e2
+      sha: e11d8fd7ccb65a5d822f7e05f1605e8c5c64a8b2
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3db042b7c381a49cf993065b940f0104023d911f1580ca3fc506a12b1c1623d1",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.06.15.15.50.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e11d8fd7ccb65a5d822f7e05f1605e8c5c64a8b2"
      }
    },
    "name": "clouddriver-armory"
  }
}
```