### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.17.58.18.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:891b98acebc4026f9afc22e98db65a941da84deb5cb3682fec9720fbb5dfbd60
+      imageId: sha256:0996c11257d6376eb76d913d01fb908e06b5a30524d33fc9f36c3ec9734987fb
       repository: armory/deck-armory
-      tag: 2021.06.15.04.40.32.master
+      tag: 2021.06.15.17.58.18.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: c75a3892bde865898d2199036cae1c821f8fa2cf
+      sha: 113533f3d2f297b454218b47d956616dbd3775ca
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:0996c11257d6376eb76d913d01fb908e06b5a30524d33fc9f36c3ec9734987fb",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.17.58.18.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "113533f3d2f297b454218b47d956616dbd3775ca"
      }
    },
    "name": "deck-armory"
  }
}
```