### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.18.40.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:2f0874afce89a45b77f0949601669253dbab356386f41f67600b2f9fd033ce4d
+      imageId: sha256:5d994aaa9705d8c7e8149379e4d2d34f78e0f4430809e718c2eb0473cd42e1c8
       repository: armory/deck-armory
-      tag: 2021.06.15.17.43.14.master
+      tag: 2021.06.15.18.40.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: aed61174a1a199a992a31f0e512b1239e5fda82d
+      sha: 710f38ea573a1e55ec3d506c06a773e3e5eb7aec
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:5d994aaa9705d8c7e8149379e4d2d34f78e0f4430809e718c2eb0473cd42e1c8",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.18.40.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "710f38ea573a1e55ec3d506c06a773e3e5eb7aec"
      }
    },
    "name": "deck-armory"
  }
}
```