### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.21.03.20.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:aaa9d196332325ba3a025a4031035872e5c2929cf74f9dd35d6081f2915ccddb
+      imageId: sha256:1cdd2920ba8d82e6e4225bb91a8544bb0228fbbbea2de87d101ec7ae19d81c9f
       repository: armory/deck-armory
-      tag: 2021.06.15.18.52.43.master
+      tag: 2021.06.15.21.03.20.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a5dac123ab49211eb0a9d237c3bb0123198655d3
+      sha: 840bea5438f6c603d3f53360646f100c4d473cd7
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:1cdd2920ba8d82e6e4225bb91a8544bb0228fbbbea2de87d101ec7ae19d81c9f",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.21.03.20.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "840bea5438f6c603d3f53360646f100c4d473cd7"
      }
    },
    "name": "deck-armory"
  }
}
```