### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.22.13.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:002ec3e7d88bc645e9d5a854abcad7bf7c15632b63f9bfcc576ed088798690d2
+      imageId: sha256:80352e320f69bae50d852cd7e959258bee6feb70d502c101085608c47b305406
       repository: armory/deck-armory
-      tag: 2021.06.15.19.56.44.master
+      tag: 2021.06.15.22.13.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a1d86d0faebad547c3ce7a202d6bef8e356e5185
+      sha: f575f1e153153959e11f8368ec2ab02369063509
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:80352e320f69bae50d852cd7e959258bee6feb70d502c101085608c47b305406",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.22.13.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f575f1e153153959e11f8368ec2ab02369063509"
      }
    },
    "name": "deck-armory"
  }
}
```