### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.22.27.01.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:002ec3e7d88bc645e9d5a854abcad7bf7c15632b63f9bfcc576ed088798690d2
+      imageId: sha256:34cc432ef5ae5c83fe0fc968d88e4b91d332781006f6e4fe86f20cce96fef437
       repository: armory/deck-armory
-      tag: 2021.06.15.19.56.44.master
+      tag: 2021.06.15.22.27.01.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a1d86d0faebad547c3ce7a202d6bef8e356e5185
+      sha: f825ae6daa28e68345394174d48dc5e1159bb2fb
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:34cc432ef5ae5c83fe0fc968d88e4b91d332781006f6e4fe86f20cce96fef437",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.22.27.01.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f825ae6daa28e68345394174d48dc5e1159bb2fb"
      }
    },
    "name": "deck-armory"
  }
}
```