### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.23.08.22.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:002ec3e7d88bc645e9d5a854abcad7bf7c15632b63f9bfcc576ed088798690d2
+      imageId: sha256:aec01d7b496af86f24136ea3941ffc6393f3a0366b692053bfd8de96a8b4269f
       repository: armory/deck-armory
-      tag: 2021.06.15.19.56.44.master
+      tag: 2021.06.15.23.08.22.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a1d86d0faebad547c3ce7a202d6bef8e356e5185
+      sha: e47b277e4ded8ff98ef23df586f04164bf33fbbb
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:aec01d7b496af86f24136ea3941ffc6393f3a0366b692053bfd8de96a8b4269f",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.23.08.22.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e47b277e4ded8ff98ef23df586f04164bf33fbbb"
      }
    },
    "name": "deck-armory"
  }
}
```