### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.23.23.17.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:002ec3e7d88bc645e9d5a854abcad7bf7c15632b63f9bfcc576ed088798690d2
+      imageId: sha256:05c748613cc0c283d752bfb14146b08222fb737cfe3dc8544ae157251a1e3636
       repository: armory/deck-armory
-      tag: 2021.06.15.19.56.44.master
+      tag: 2021.06.15.23.23.17.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a1d86d0faebad547c3ce7a202d6bef8e356e5185
+      sha: 50041ef0f3d758103fdd5a1436f66e34c31068a7
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:05c748613cc0c283d752bfb14146b08222fb737cfe3dc8544ae157251a1e3636",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.23.23.17.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "50041ef0f3d758103fdd5a1436f66e34c31068a7"
      }
    },
    "name": "deck-armory"
  }
}
```