### PR TITLE
chore(cd): update deck-armory version to 2021.06.15.23.35.49.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:002ec3e7d88bc645e9d5a854abcad7bf7c15632b63f9bfcc576ed088798690d2
+      imageId: sha256:19516702f70816cf5799c1cf05969ba053d68f38cafba9873a41c82b62536ce1
       repository: armory/deck-armory
-      tag: 2021.06.15.19.56.44.master
+      tag: 2021.06.15.23.35.49.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a1d86d0faebad547c3ce7a202d6bef8e356e5185
+      sha: 2d76a955c2079df4c18a6b6bd9982e5860da5d2e
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:19516702f70816cf5799c1cf05969ba053d68f38cafba9873a41c82b62536ce1",
        "repository": "armory/deck-armory",
        "tag": "2021.06.15.23.35.49.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "2d76a955c2079df4c18a6b6bd9982e5860da5d2e"
      }
    },
    "name": "deck-armory"
  }
}
```