### PR TITLE
chore(cd): update deck-armory version to 2021.06.16.00.37.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:ee3cc8a42aa7f48edc3282c7f4c452889c06210fed1a06289eca8db7a1ed6d76
+      imageId: sha256:bf003fa66b6007d65f42b0b39304ea81691a09ac473814efd3bae6f176983e9e
       repository: armory/deck-armory
-      tag: 2021.06.15.21.58.19.master
+      tag: 2021.06.16.00.37.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 083f04d11f9d0eb62cb1764daa34383b65a8da69
+      sha: 06c26118c1912578e9af4bf791bd2c77d20564cc
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:bf003fa66b6007d65f42b0b39304ea81691a09ac473814efd3bae6f176983e9e",
        "repository": "armory/deck-armory",
        "tag": "2021.06.16.00.37.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "06c26118c1912578e9af4bf791bd2c77d20564cc"
      }
    },
    "name": "deck-armory"
  }
}
```