### PR TITLE
chore(cd): update deck-armory version to 2021.06.16.00.49.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:ee3cc8a42aa7f48edc3282c7f4c452889c06210fed1a06289eca8db7a1ed6d76
+      imageId: sha256:69432c1bdcd10875bbabb04a9a717021b925f078b39a3f79bae4d15243f032c1
       repository: armory/deck-armory
-      tag: 2021.06.15.21.58.19.master
+      tag: 2021.06.16.00.49.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 083f04d11f9d0eb62cb1764daa34383b65a8da69
+      sha: 38b91d0c6b6dfadcd56ad1043d754c51c576e3fb
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:69432c1bdcd10875bbabb04a9a717021b925f078b39a3f79bae4d15243f032c1",
        "repository": "armory/deck-armory",
        "tag": "2021.06.16.00.49.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "38b91d0c6b6dfadcd56ad1043d754c51c576e3fb"
      }
    },
    "name": "deck-armory"
  }
}
```