### PR TITLE
chore(cd): update fiat-armory version to 2021.06.08.23.26.27.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,16 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
+  fiat-armory:
+    baseService: fiat
     image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
+      imageId: sha256:4de0066da4189395430deb028d783ae97be18490fa11a76a3cefd649700edc3d
+      repository: armory/fiat-armory
+      tag: 2021.06.08.23.26.27.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: kayenta-armory
+        repoName: fiat-armory
         type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
+      sha: efd746b27fc7dfb26d1245938499180d92f0eb88
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +23,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:4de0066da4189395430deb028d783ae97be18490fa11a76a3cefd649700edc3d",
        "repository": "armory/fiat-armory",
        "tag": "2021.06.08.23.26.27.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "efd746b27fc7dfb26d1245938499180d92f0eb88"
      }
    },
    "name": "fiat-armory"
  }
}
```