### PR TITLE
chore(cd): update igor-armory version to 2021.06.09.20.37.45.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,4 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
-    image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: kayenta-armory
-        type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +11,30 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  igor-armory:
+    baseService: igor
+    image:
+      imageId: sha256:db078dd8d2b5acc811f1bd78658bc195a0dd00c654fe2577ca301fac7beabdf6
+      repository: armory/igor-armory
+      tag: 2021.06.09.20.37.45.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: igor-armory
+        type: github
+      sha: d2ed244bf5f34c26b546e465b39e3cb6af840677
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:db078dd8d2b5acc811f1bd78658bc195a0dd00c654fe2577ca301fac7beabdf6",
        "repository": "armory/igor-armory",
        "tag": "2021.06.09.20.37.45.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "d2ed244bf5f34c26b546e465b39e3cb6af840677"
      }
    },
    "name": "igor-armory"
  }
}
```