### PR TITLE
chore(cd): update deck-armory version to 2021.06.23.12.56.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:6128548001e130f91dcac62e7436329283e93f8de02e42971ece2f1461c9dff2
+      imageId: sha256:4df60feb7be55ab2623f5397a9458abc9012635966eccf7c143f85e44c0786c8
       repository: armory/deck-armory
-      tag: 2021.06.16.01.13.58.master
+      tag: 2021.06.23.12.56.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e3c47922337bd596ef05f11eeaf759a00f60cdfa
+      sha: fa2f16e1c8439b8563ecd907bd92263318f0980d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:4df60feb7be55ab2623f5397a9458abc9012635966eccf7c143f85e44c0786c8",
        "repository": "armory/deck-armory",
        "tag": "2021.06.23.12.56.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "fa2f16e1c8439b8563ecd907bd92263318f0980d"
      }
    },
    "name": "deck-armory"
  }
}
```