### PR TITLE
chore(cd): update deck-armory version to 2021.06.23.14.52.14.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:6128548001e130f91dcac62e7436329283e93f8de02e42971ece2f1461c9dff2
+      imageId: sha256:973ec0e7e8a37604c452d7d169a416667124d807b890a622096ab262b059c38f
       repository: armory/deck-armory
-      tag: 2021.06.16.01.13.58.master
+      tag: 2021.06.23.14.52.14.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e3c47922337bd596ef05f11eeaf759a00f60cdfa
+      sha: b39ac2d45140120662bb8114ff45f1e7eaa6c4a6
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:973ec0e7e8a37604c452d7d169a416667124d807b890a622096ab262b059c38f",
        "repository": "armory/deck-armory",
        "tag": "2021.06.23.14.52.14.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "b39ac2d45140120662bb8114ff45f1e7eaa6c4a6"
      }
    },
    "name": "deck-armory"
  }
}
```