### PR TITLE
chore(cd): update deck-armory version to 2021.06.23.21.00.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:8414c078c38893e8446801c87a90dec8c5e3e57cdb58d9e148d7dbe2d3ebeddd
+      imageId: sha256:25e6d941e39cd03f74306a9b97d93aa9773ab519eb24f384e63c87ff09b520dd
       repository: armory/deck-armory
-      tag: 2021.06.23.15.48.45.master
+      tag: 2021.06.23.21.00.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a9f5c2b3611d107ff8b26deca98940dfafdb5f74
+      sha: 969ad34783253db633fa537ad2e26aed026cf292
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:25e6d941e39cd03f74306a9b97d93aa9773ab519eb24f384e63c87ff09b520dd",
        "repository": "armory/deck-armory",
        "tag": "2021.06.23.21.00.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "969ad34783253db633fa537ad2e26aed026cf292"
      }
    },
    "name": "deck-armory"
  }
}
```