### PR TITLE
chore(cd): update clouddriver-armory version to 2021.06.29.00.51.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:848bad63827e580f9bbeebdbebae1df5af149c5fd6cf5155df60edf6c831e995
+      imageId: sha256:783a7b213b237fdd128b797e68cdf98932a0c44be257265a77bd2807160c4b50
       repository: armory/clouddriver-armory
-      tag: 2021.06.25.22.52.08.master
+      tag: 2021.06.29.00.51.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c2026e2e26076edf418b0129976b38779792684b
+      sha: 3908f585d2d4d8e32fd097c73924b406113a5b9f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:783a7b213b237fdd128b797e68cdf98932a0c44be257265a77bd2807160c4b50",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.06.29.00.51.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3908f585d2d4d8e32fd097c73924b406113a5b9f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```