### PR TITLE
chore(cd): update echo-armory version to 2021.06.09.20.39.26.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,16 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
+  echo-armory:
+    baseService: echo
     image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
+      imageId: sha256:71aabd5b7b6812bba1a3cb04dd1c660e79a30b947d979880f10d78c1230625c7
+      repository: armory/echo-armory
+      tag: 2021.06.09.20.39.26.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: kayenta-armory
+        repoName: echo-armory
         type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
+      sha: 5ebc96e8026209d786491b2abebb614b77128abc
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +23,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:71aabd5b7b6812bba1a3cb04dd1c660e79a30b947d979880f10d78c1230625c7",
        "repository": "armory/echo-armory",
        "tag": "2021.06.09.20.39.26.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "5ebc96e8026209d786491b2abebb614b77128abc"
      }
    },
    "name": "echo-armory"
  }
}
```