### PR TITLE
chore(cd): update front50-armory version to 2021.06.29.20.33.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:c89c59f60b22c4b514ee704731cfdee907b59252d70b3cf8428fc544154e7535
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.06.29.20.33.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: 6e486ba6917958766423e71d265fddf48824c3e5
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c89c59f60b22c4b514ee704731cfdee907b59252d70b3cf8428fc544154e7535",
        "repository": "armory/front50-armory",
        "tag": "2021.06.29.20.33.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "6e486ba6917958766423e71d265fddf48824c3e5"
      }
    },
    "name": "front50-armory"
  }
}
```