### PR TITLE
chore(cd): update clouddriver-armory version to 2021.06.29.20.39.55.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:848bad63827e580f9bbeebdbebae1df5af149c5fd6cf5155df60edf6c831e995
+      imageId: sha256:82a8e4a3609d319033bc9726caeeefab334667472f3705edc4fb92262b5f1429
       repository: armory/clouddriver-armory
-      tag: 2021.06.25.22.52.08.master
+      tag: 2021.06.29.20.39.55.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c2026e2e26076edf418b0129976b38779792684b
+      sha: bc115c91350d689fa7698a6dde804ab52e230c8b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:82a8e4a3609d319033bc9726caeeefab334667472f3705edc4fb92262b5f1429",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.06.29.20.39.55.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "bc115c91350d689fa7698a6dde804ab52e230c8b"
      }
    },
    "name": "clouddriver-armory"
  }
}
```