### PR TITLE
chore(cd): update clouddriver-armory version to 2021.06.30.21.37.54.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,16 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
+  clouddriver-armory:
+    baseService: clouddriver
     image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
+      imageId: sha256:329fbc2b5248f5625216215e4a8914f67f5509eb7b087583cfd7fa0a594c49fd
+      repository: armory/clouddriver-armory
+      tag: 2021.06.30.21.37.54.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: kayenta-armory
+        repoName: clouddriver-armory
         type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
+      sha: 8f44cdaaf6dd44c1a08f7364adb70f909311ed0f
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +23,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:329fbc2b5248f5625216215e4a8914f67f5509eb7b087583cfd7fa0a594c49fd",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.06.30.21.37.54.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8f44cdaaf6dd44c1a08f7364adb70f909311ed0f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```