### PR TITLE
chore(cd): update echo-armory version to 2021.06.30.21.57.57.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,16 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
+  echo-armory:
+    baseService: echo
     image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
+      imageId: sha256:ed18f5c60e870cf4bff1fee84be55a0fdbcecde8e1f92567c017f0d03b0cb5a3
+      repository: armory/echo-armory
+      tag: 2021.06.30.21.57.57.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: kayenta-armory
+        repoName: echo-armory
         type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
+      sha: 68402152407daa8ddca2fee6887e65df0903b5fe
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +23,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:ed18f5c60e870cf4bff1fee84be55a0fdbcecde8e1f92567c017f0d03b0cb5a3",
        "repository": "armory/echo-armory",
        "tag": "2021.06.30.21.57.57.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "68402152407daa8ddca2fee6887e65df0903b5fe"
      }
    },
    "name": "echo-armory"
  }
}
```