### PR TITLE
chore(cd): update kayenta-armory version to 2021.07.01.00.55.22.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,4 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
-    image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: kayenta-armory
-        type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +11,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:2f07916f641dbd7c1336771b92a6a8a47e272a26a6ffad5b72a952fe4d8921c0
+      repository: armory/kayenta-armory
+      tag: 2021.07.01.00.55.22.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: d3537dabdb6caf2c70b025903f68d6adbedf3de7
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:2f07916f641dbd7c1336771b92a6a8a47e272a26a6ffad5b72a952fe4d8921c0",
        "repository": "armory/kayenta-armory",
        "tag": "2021.07.01.00.55.22.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "d3537dabdb6caf2c70b025903f68d6adbedf3de7"
      }
    },
    "name": "kayenta-armory"
  }
}
```