### PR TITLE
chore(cd): update deck-armory version to 2021.07.01.01.14.34.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:58942e84522b29370eb678a375d2fa729c93288342e15865725764bc55dae16b
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.01.01.14.34.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 88768dfadffa6cf45419f28364f5b3c37355809d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:58942e84522b29370eb678a375d2fa729c93288342e15865725764bc55dae16b",
        "repository": "armory/deck-armory",
        "tag": "2021.07.01.01.14.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "88768dfadffa6cf45419f28364f5b3c37355809d"
      }
    },
    "name": "deck-armory"
  }
}
```