### PR TITLE
chore(cd): update echo-armory version to 2021.07.01.01.55.04.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,16 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
+  echo-armory:
+    baseService: echo
     image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
+      imageId: sha256:34fb98b2d04244eab519423fcad000e85cdf6a552d130405c25025d91c09c7eb
+      repository: armory/echo-armory
+      tag: 2021.07.01.01.55.04.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: kayenta-armory
+        repoName: echo-armory
         type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
+      sha: 3cdb74fa9901fd1a47512dfae47cbb88ec8827fa
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +23,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:34fb98b2d04244eab519423fcad000e85cdf6a552d130405c25025d91c09c7eb",
        "repository": "armory/echo-armory",
        "tag": "2021.07.01.01.55.04.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "3cdb74fa9901fd1a47512dfae47cbb88ec8827fa"
      }
    },
    "name": "echo-armory"
  }
}
```