### PR TITLE
chore(cd): update deck-armory version to 2021.07.01.06.33.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:e18ee74efe395b47e1c16cce5632751bb5754167565c8f6c956eee39452be61a
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.01.06.33.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 0b736a176a8d071e37b44cd34774a9d352e134f5
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:e18ee74efe395b47e1c16cce5632751bb5754167565c8f6c956eee39452be61a",
        "repository": "armory/deck-armory",
        "tag": "2021.07.01.06.33.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "0b736a176a8d071e37b44cd34774a9d352e134f5"
      }
    },
    "name": "deck-armory"
  }
}
```