### PR TITLE
chore(cd): update deck-armory version to 2021.07.01.19.28.29.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:f5f55540fdf3cf250ad56740bce0bd1958e1671ae1c34b28a49bfc2ad6bdae40
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.01.19.28.29.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 36d5d297a30e90f7b3aab8e248f0220b1276b05f
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:f5f55540fdf3cf250ad56740bce0bd1958e1671ae1c34b28a49bfc2ad6bdae40",
        "repository": "armory/deck-armory",
        "tag": "2021.07.01.19.28.29.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "36d5d297a30e90f7b3aab8e248f0220b1276b05f"
      }
    },
    "name": "deck-armory"
  }
}
```