### PR TITLE
chore(cd): update deck-armory version to 2021.07.01.19.48.18.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:bb2a705f00921059652d8fa18ef12fcf508df36edae4688a66b34d0f12968db4
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.01.19.48.18.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 1a41bbf4380c8b22d58ce7390877ce6ad5584f1f
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:bb2a705f00921059652d8fa18ef12fcf508df36edae4688a66b34d0f12968db4",
        "repository": "armory/deck-armory",
        "tag": "2021.07.01.19.48.18.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1a41bbf4380c8b22d58ce7390877ce6ad5584f1f"
      }
    },
    "name": "deck-armory"
  }
}
```