### PR TITLE
chore(cd): update deck-armory version to 2021.07.02.08.32.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:972354ada208cf3c9f40271661917fad1b1e4cb18b22cc09021754a911c16c97
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.02.08.32.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 52492528f11644ca62d1b74dccbc33a674f08fb2
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:972354ada208cf3c9f40271661917fad1b1e4cb18b22cc09021754a911c16c97",
        "repository": "armory/deck-armory",
        "tag": "2021.07.02.08.32.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "52492528f11644ca62d1b74dccbc33a674f08fb2"
      }
    },
    "name": "deck-armory"
  }
}
```