### PR TITLE
chore(cd): update clouddriver-armory version to 2021.07.02.19.00.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:848bad63827e580f9bbeebdbebae1df5af149c5fd6cf5155df60edf6c831e995
+      imageId: sha256:25b741ab007c72d0e63cd309a21df58dfabb35b7fc6a0d1c2018cdf71f2930af
       repository: armory/clouddriver-armory
-      tag: 2021.06.25.22.52.08.master
+      tag: 2021.07.02.19.00.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c2026e2e26076edf418b0129976b38779792684b
+      sha: 200487ba1b0c9ee16428c88dd6c38d340476ad60
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:25b741ab007c72d0e63cd309a21df58dfabb35b7fc6a0d1c2018cdf71f2930af",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.07.02.19.00.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "200487ba1b0c9ee16428c88dd6c38d340476ad60"
      }
    },
    "name": "clouddriver-armory"
  }
}
```