### PR TITLE
chore(cd): update igor-armory version to 2021.07.01.00.56.20.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,4 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
-    image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: kayenta-armory
-        type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +11,30 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  igor-armory:
+    baseService: igor
+    image:
+      imageId: sha256:9ba6bd08f4e268b27f9135116ffd2700ad376246136a81353e175d7e1671fccf
+      repository: armory/igor-armory
+      tag: 2021.07.01.00.56.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: igor-armory
+        type: github
+      sha: a9b45bca07fb1c5bf14e37467498580316451e68
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:9ba6bd08f4e268b27f9135116ffd2700ad376246136a81353e175d7e1671fccf",
        "repository": "armory/igor-armory",
        "tag": "2021.07.01.00.56.20.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "a9b45bca07fb1c5bf14e37467498580316451e68"
      }
    },
    "name": "igor-armory"
  }
}
```