### PR TITLE
chore(cd): update front50-armory version to 2021.07.02.16.32.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:3d247a87b5b31196a0394d8c456fff3284fd06b4263d631520c610030c4ad85c
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.07.02.16.32.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: e88311e3d2afa7e442b7f03fd3701ad111a77bce
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:3d247a87b5b31196a0394d8c456fff3284fd06b4263d631520c610030c4ad85c",
        "repository": "armory/front50-armory",
        "tag": "2021.07.02.16.32.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "e88311e3d2afa7e442b7f03fd3701ad111a77bce"
      }
    },
    "name": "front50-armory"
  }
}
```