### PR TITLE
chore(cd): update gate-armory version to 2021.07.01.01.51.33.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,4 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
-    image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: kayenta-armory
-        type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +11,30 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  gate-armory:
+    baseService: gate
+    image:
+      imageId: sha256:2d5781955c8f5068e27b796bf109798db8c99d57d23abc4c990bf7969cd4ebca
+      repository: armory/gate-armory
+      tag: 2021.07.01.01.51.33.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: gate-armory
+        type: github
+      sha: ec2ae48cda93986528077e735f4c47e45f51c0ca
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
+      repository: armory/kayenta-armory
+      tag: 2021.06.08.23.38.20.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: acccf803484acfb43847a50a0405aa082fc1c943
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:2d5781955c8f5068e27b796bf109798db8c99d57d23abc4c990bf7969cd4ebca",
        "repository": "armory/gate-armory",
        "tag": "2021.07.01.01.51.33.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "ec2ae48cda93986528077e735f4c47e45f51c0ca"
      }
    },
    "name": "gate-armory"
  }
}
```