### PR TITLE
chore(cd): update deck-armory version to 2021.07.02.21.49.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:0f7e6134dfbb405a682e065c1956cf13f5a66c9c32f433eb74071ee2af03dc17
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.02.21.49.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 2b3a340bd68af2c56713783446f3c351896ebda3
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:0f7e6134dfbb405a682e065c1956cf13f5a66c9c32f433eb74071ee2af03dc17",
        "repository": "armory/deck-armory",
        "tag": "2021.07.02.21.49.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "2b3a340bd68af2c56713783446f3c351896ebda3"
      }
    },
    "name": "deck-armory"
  }
}
```