### PR TITLE
chore(cd): update deck-armory version to 2021.07.03.06.02.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:7f5abe3cee236e5684ae8d57b47246943f85b2a301ac422aa18b45b52dcd2cee
+      imageId: sha256:7f684aa49cb6c13cdbedcff111d1804ac0482ac807bb4da97cfa2df9eaf639bf
       repository: armory/deck-armory
-      tag: 2021.06.24.18.16.21.master
+      tag: 2021.07.03.06.02.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 8134b6012bc452fac7a897b9efaca4a70ab9579b
+      sha: 4230c40c604947a0c716bc25e05abafd988aa48d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:7f684aa49cb6c13cdbedcff111d1804ac0482ac807bb4da97cfa2df9eaf639bf",
        "repository": "armory/deck-armory",
        "tag": "2021.07.03.06.02.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "4230c40c604947a0c716bc25e05abafd988aa48d"
      }
    },
    "name": "deck-armory"
  }
}
```