### PR TITLE
chore(cd): update kayenta-armory version to 2021.07.06.22.22.40.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,16 +1,4 @@
 services:
-  kayenta-armory:
-    baseService: kayenta
-    image:
-      imageId: sha256:f704f94ad800431b94bc57533071804e4a8cc65d712d485613d2afeb953575b6
-      repository: armory/kayenta-armory
-      tag: 2021.06.08.23.38.20.release-2.26.x
-    vcs:
-      repo:
-        orgName: armory-io
-        repoName: kayenta-armory
-        type: github
-      sha: acccf803484acfb43847a50a0405aa082fc1c943
   front50-armory:
     baseService: front50
     image:
@@ -23,6 +11,18 @@ services:
         repoName: front50-armory
         type: github
       sha: 0fff032f382fb813cd78024d8313a876989f468e
+  kayenta-armory:
+    baseService: kayenta
+    image:
+      imageId: sha256:0f44b46ebc374d8c812a08466d98b2343493e986822daba971c8274c995f7b41
+      repository: armory/kayenta-armory
+      tag: 2021.07.06.22.22.40.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: kayenta-armory
+        type: github
+      sha: 1d27eaf7f8f9d38ac05877fce7b0f740e4e7de39
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:0f44b46ebc374d8c812a08466d98b2343493e986822daba971c8274c995f7b41",
        "repository": "armory/kayenta-armory",
        "tag": "2021.07.06.22.22.40.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "1d27eaf7f8f9d38ac05877fce7b0f740e4e7de39"
      }
    },
    "name": "kayenta-armory"
  }
}
```