### PR TITLE
chore(cd): update clouddriver-armory version to 2021.07.07.18.00.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:848bad63827e580f9bbeebdbebae1df5af149c5fd6cf5155df60edf6c831e995
+      imageId: sha256:01ae082f414fe1cd57adb388ceaf4722917418dc363714df515167ef42106d5e
       repository: armory/clouddriver-armory
-      tag: 2021.06.25.22.52.08.master
+      tag: 2021.07.07.18.00.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c2026e2e26076edf418b0129976b38779792684b
+      sha: 60caa35e85b8768610e01856d72f6d828d45d31a
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:01ae082f414fe1cd57adb388ceaf4722917418dc363714df515167ef42106d5e",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.07.07.18.00.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "60caa35e85b8768610e01856d72f6d828d45d31a"
      }
    },
    "name": "clouddriver-armory"
  }
}
```