### PR TITLE
chore(cd): update clouddriver-armory version to 2021.07.08.00.03.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:848bad63827e580f9bbeebdbebae1df5af149c5fd6cf5155df60edf6c831e995
+      imageId: sha256:26cebb41f8e3a87a85e64bf115984e0b2ae9cad42441a01e410d3d56f7b21274
       repository: armory/clouddriver-armory
-      tag: 2021.06.25.22.52.08.master
+      tag: 2021.07.08.00.03.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c2026e2e26076edf418b0129976b38779792684b
+      sha: 8dc5c303b8c86b96d1689b6686108a3c57a43bd8
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:26cebb41f8e3a87a85e64bf115984e0b2ae9cad42441a01e410d3d56f7b21274",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.07.08.00.03.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8dc5c303b8c86b96d1689b6686108a3c57a43bd8"
      }
    },
    "name": "clouddriver-armory"
  }
}
```