### PR TITLE
chore(cd): update front50-armory version to 2021.07.09.15.41.02.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:3fa0bd3e673c9016e3f4490e87245596f876f080bfbd2fcc1568e0c0f408deee
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.07.09.15.41.02.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: b26ed40f22da9985e4701753874aafa67ca93627
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:3fa0bd3e673c9016e3f4490e87245596f876f080bfbd2fcc1568e0c0f408deee",
        "repository": "armory/front50-armory",
        "tag": "2021.07.09.15.41.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "b26ed40f22da9985e4701753874aafa67ca93627"
      }
    },
    "name": "front50-armory"
  }
}
```