### PR TITLE
chore(cd): update clouddriver-armory version to 2021.07.09.18.53.34.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:848bad63827e580f9bbeebdbebae1df5af149c5fd6cf5155df60edf6c831e995
+      imageId: sha256:8d3bca7d54308000218aef11a4560ca4527de90fc8469db44984d1502d27c851
       repository: armory/clouddriver-armory
-      tag: 2021.06.25.22.52.08.master
+      tag: 2021.07.09.18.53.34.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c2026e2e26076edf418b0129976b38779792684b
+      sha: 47387e2bc0d2ed198d1bdb8057dce1a443e77c23
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8d3bca7d54308000218aef11a4560ca4527de90fc8469db44984d1502d27c851",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.07.09.18.53.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "47387e2bc0d2ed198d1bdb8057dce1a443e77c23"
      }
    },
    "name": "clouddriver-armory"
  }
}
```