### PR TITLE
chore(cd): update terraformer version to 2021.07.15.17.11.22.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:99fdb8d00a2f32d9181dfba78fabdeb6fef28bc1f4f0d0ae3c9ba27e56a1a7ad
+      imageId: sha256:647ebb06bdbf9bcd84ffd4f95ad790e9236eaea0258883427d62a9b1fd82940c
       repository: armory/terraformer
-      tag: 2021.07.14.20.02.28.master
+      tag: 2021.07.15.17.11.22.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 3d0fc43c2278a1713adcf8687cdfbb50ffecfb78
+      sha: 717efc9563cee20cb9c37068db976d9598461e1e


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:647ebb06bdbf9bcd84ffd4f95ad790e9236eaea0258883427d62a9b1fd82940c",
        "repository": "armory/terraformer",
        "tag": "2021.07.15.17.11.22.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "717efc9563cee20cb9c37068db976d9598461e1e"
      }
    },
    "name": "terraformer"
  }
}
```