### PR TITLE
chore(cd): update front50-armory version to 2021.07.16.21.10.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:650a821f01ae5d43d467518e8394faa88705e93a8a626039c064ca8f8ffbab1b
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.07.16.21.10.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: 6190f6f01a67c59b1bacf3bb1a37b5c019ef2a5d
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:650a821f01ae5d43d467518e8394faa88705e93a8a626039c064ca8f8ffbab1b",
        "repository": "armory/front50-armory",
        "tag": "2021.07.16.21.10.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "6190f6f01a67c59b1bacf3bb1a37b5c019ef2a5d"
      }
    },
    "name": "front50-armory"
  }
}
```