### PR TITLE
chore(cd): update deck-armory version to 2021.07.17.20.41.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:23fb2a3e574ebc5df4b265430d5e0d81a433ef8bcd994007eb8d675d3f230c35
+      imageId: sha256:218c70f9479edbb3c93a12a82c5ef36c7a6dea862528451b56041b21bf89c9d3
       repository: armory/deck-armory
-      tag: 2021.07.16.19.50.31.master
+      tag: 2021.07.17.20.41.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e232ace966676ecc431d5ff51625c59ac54cd18a
+      sha: 773a4966ddcc06dfd099916f13d1653aea39fb1f
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:218c70f9479edbb3c93a12a82c5ef36c7a6dea862528451b56041b21bf89c9d3",
        "repository": "armory/deck-armory",
        "tag": "2021.07.17.20.41.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "773a4966ddcc06dfd099916f13d1653aea39fb1f"
      }
    },
    "name": "deck-armory"
  }
}
```