### PR TITLE
chore(cd): update deck-armory version to 2021.07.17.21.07.23.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:23fb2a3e574ebc5df4b265430d5e0d81a433ef8bcd994007eb8d675d3f230c35
+      imageId: sha256:0cb4f183fd26e69c743570ebf89afa10aa24ae7c3cc81548e9bcf6aed99f4704
       repository: armory/deck-armory
-      tag: 2021.07.16.19.50.31.master
+      tag: 2021.07.17.21.07.23.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e232ace966676ecc431d5ff51625c59ac54cd18a
+      sha: d37b0b2b8ccd66ab3b92e3455620db51f5cb531d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:0cb4f183fd26e69c743570ebf89afa10aa24ae7c3cc81548e9bcf6aed99f4704",
        "repository": "armory/deck-armory",
        "tag": "2021.07.17.21.07.23.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "d37b0b2b8ccd66ab3b92e3455620db51f5cb531d"
      }
    },
    "name": "deck-armory"
  }
}
```