### PR TITLE
chore(cd): update deck-armory version to 2021.07.18.02.05.08.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:23fb2a3e574ebc5df4b265430d5e0d81a433ef8bcd994007eb8d675d3f230c35
+      imageId: sha256:3dd38d23b7ba1d4aefe8582532e4e1874098fc1a4a1573c54dfabe3fc6a72f44
       repository: armory/deck-armory
-      tag: 2021.07.16.19.50.31.master
+      tag: 2021.07.18.02.05.08.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e232ace966676ecc431d5ff51625c59ac54cd18a
+      sha: 5c3ccc7c9e5686e5bf52fcedab4a2116eb9aeb4c
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3dd38d23b7ba1d4aefe8582532e4e1874098fc1a4a1573c54dfabe3fc6a72f44",
        "repository": "armory/deck-armory",
        "tag": "2021.07.18.02.05.08.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "5c3ccc7c9e5686e5bf52fcedab4a2116eb9aeb4c"
      }
    },
    "name": "deck-armory"
  }
}
```