### PR TITLE
chore(cd): update deck-armory version to 2021.07.18.18.21.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:23fb2a3e574ebc5df4b265430d5e0d81a433ef8bcd994007eb8d675d3f230c35
+      imageId: sha256:a11a07d3e3285d72ba4511a246ec3fd1047f3467f38f035468b36f0e3ab073d5
       repository: armory/deck-armory
-      tag: 2021.07.16.19.50.31.master
+      tag: 2021.07.18.18.21.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e232ace966676ecc431d5ff51625c59ac54cd18a
+      sha: 2da6474ca4d5219fe827ea5ff1cf19a5c290e71b
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a11a07d3e3285d72ba4511a246ec3fd1047f3467f38f035468b36f0e3ab073d5",
        "repository": "armory/deck-armory",
        "tag": "2021.07.18.18.21.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "2da6474ca4d5219fe827ea5ff1cf19a5c290e71b"
      }
    },
    "name": "deck-armory"
  }
}
```