### PR TITLE
chore(cd): update deck-armory version to 2021.07.19.21.21.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:23fb2a3e574ebc5df4b265430d5e0d81a433ef8bcd994007eb8d675d3f230c35
+      imageId: sha256:e68af43f8a83cb7c507e47bc62a6a39cf90c467a226e82bb15e9956db7af0ce1
       repository: armory/deck-armory
-      tag: 2021.07.16.19.50.31.master
+      tag: 2021.07.19.21.21.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e232ace966676ecc431d5ff51625c59ac54cd18a
+      sha: 63c06732923aae404743744c61fe77d6b65ead87
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:e68af43f8a83cb7c507e47bc62a6a39cf90c467a226e82bb15e9956db7af0ce1",
        "repository": "armory/deck-armory",
        "tag": "2021.07.19.21.21.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "63c06732923aae404743744c61fe77d6b65ead87"
      }
    },
    "name": "deck-armory"
  }
}
```