### PR TITLE
chore(cd): update deck-armory version to 2021.07.19.22.41.04.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:23fb2a3e574ebc5df4b265430d5e0d81a433ef8bcd994007eb8d675d3f230c35
+      imageId: sha256:6c91c65f6695e9752a61ab6180bba378c914b18473908979e1969aa66b4075cf
       repository: armory/deck-armory
-      tag: 2021.07.16.19.50.31.master
+      tag: 2021.07.19.22.41.04.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e232ace966676ecc431d5ff51625c59ac54cd18a
+      sha: 0cd0ec70b2124fec0b0f542b6c8d7eea8a7641f7
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:6c91c65f6695e9752a61ab6180bba378c914b18473908979e1969aa66b4075cf",
        "repository": "armory/deck-armory",
        "tag": "2021.07.19.22.41.04.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "0cd0ec70b2124fec0b0f542b6c8d7eea8a7641f7"
      }
    },
    "name": "deck-armory"
  }
}
```