### PR TITLE
chore(cd): update front50-armory version to 2021.07.20.15.26.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:5fef1cd9d1c4808038e9c2f27a01031700945964e105088f752168c5a8fd2323
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.07.20.15.26.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: 56c466ebbccbf8744c814a1049591bd6246b0e3a
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:5fef1cd9d1c4808038e9c2f27a01031700945964e105088f752168c5a8fd2323",
        "repository": "armory/front50-armory",
        "tag": "2021.07.20.15.26.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "56c466ebbccbf8744c814a1049591bd6246b0e3a"
      }
    },
    "name": "front50-armory"
  }
}
```