### PR TITLE
chore(cd): update front50-armory version to 2021.07.20.22.30.23.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:c9c6c114489645b421c180ea918ae5dfd11ca0e429a0b22c81bbd5affb5912eb
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.07.20.22.30.23.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: bd6f4a4993476c32d8112aa137985877157fa197
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c9c6c114489645b421c180ea918ae5dfd11ca0e429a0b22c81bbd5affb5912eb",
        "repository": "armory/front50-armory",
        "tag": "2021.07.20.22.30.23.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "bd6f4a4993476c32d8112aa137985877157fa197"
      }
    },
    "name": "front50-armory"
  }
}
```