### PR TITLE
chore(cd): update rosco-armory version to 2021.07.21.22.38.02.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:21a310c17abc4a641f0849f9e517e23c51240ec0a25b4b16c3db19d8d409ef7a
+      imageId: sha256:61aeeb7a68daec6f07e28bd1ecd97a8ecb6ef5bc6ca5eb142917db9747dc2603
       repository: armory/rosco-armory
-      tag: 2021.07.02.22.22.09.master
+      tag: 2021.07.21.22.38.02.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 34a3f0a0505ffc6091af83a5e774247e7fe04bcf
+      sha: 42103e208c025e1cba26bc818dd17139458689f4
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:61aeeb7a68daec6f07e28bd1ecd97a8ecb6ef5bc6ca5eb142917db9747dc2603",
        "repository": "armory/rosco-armory",
        "tag": "2021.07.21.22.38.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "42103e208c025e1cba26bc818dd17139458689f4"
      }
    },
    "name": "rosco-armory"
  }
}
```