### PR TITLE
chore(cd): update front50-armory version to 2021.07.23.20.57.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:a6395f13b5bc93627b2a6aa56630b77a494a787fe2e09a21c232fa700cc9a2f2
+      imageId: sha256:444dff4b4c7000b4a92ea885ab8b694f57e54119a9d0b71473b607247dbad824
       repository: armory/front50-armory
-      tag: 2021.06.11.20.05.05.master
+      tag: 2021.07.23.20.57.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b9a03c0d3379283a1701fd25bd3c716d68057ed6
+      sha: af8e0fdc31a7d0413650cf97a9f34e8bbc9b755e
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "b082bae3c459abaf9da959e3084508804a60c6c2"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:444dff4b4c7000b4a92ea885ab8b694f57e54119a9d0b71473b607247dbad824",
        "repository": "armory/front50-armory",
        "tag": "2021.07.23.20.57.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "af8e0fdc31a7d0413650cf97a9f34e8bbc9b755e"
      }
    },
    "name": "front50-armory"
  }
}
```