### PR TITLE
chore(cd): update clouddriver-armory version to 2021.07.28.20.02.15.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,4 +1,16 @@
 services:
+  clouddriver-armory:
+    baseService: clouddriver
+    image:
+      imageId: sha256:2dff140362dc50cf9a8137c2ac3c93eb194e69a0e83c5ee6a548fa556ee884ca
+      repository: armory/clouddriver-armory
+      tag: 2021.07.28.20.02.15.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: clouddriver-armory
+        type: github
+      sha: 172406face4e7bc74888920de6ec24284d735f51
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "caffe451db979b08a43b36b9f47e5343e6405856"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2dff140362dc50cf9a8137c2ac3c93eb194e69a0e83c5ee6a548fa556ee884ca",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.07.28.20.02.15.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "172406face4e7bc74888920de6ec24284d735f51"
      }
    },
    "name": "clouddriver-armory"
  }
}
```