### PR TITLE
chore(cd): update clouddriver-armory version to 2021.07.29.00.17.19.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -1,4 +1,16 @@
 services:
+  clouddriver-armory:
+    baseService: clouddriver
+    image:
+      imageId: sha256:dadad136df89ca90c5d6782fc335fb21c17566183b6f8362cedbd06450452fac
+      repository: armory/clouddriver-armory
+      tag: 2021.07.29.00.17.19.release-2.26.x
+    vcs:
+      repo:
+        orgName: armory-io
+        repoName: clouddriver-armory
+        type: github
+      sha: 60104232429232571b5dc520a8966ed66c606df2
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "09b47bd590ae8aef580c89f645437940593675e0"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:dadad136df89ca90c5d6782fc335fb21c17566183b6f8362cedbd06450452fac",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.07.29.00.17.19.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "60104232429232571b5dc520a8966ed66c606df2"
      }
    },
    "name": "clouddriver-armory"
  }
}
```