### PR TITLE
chore(cd): update front50-armory version to 2021.08.03.20.54.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:d78a78e084ce7619e6b92a4e3ee69db4095d1b92f9dbf240b251231fd4f162f6
+      imageId: sha256:f0ed70eaf9906353924fed76ec832ffb1fd01f970908198fcb095e95fcbe279e
       repository: armory/front50-armory
-      tag: 2021.07.27.04.36.03.master
+      tag: 2021.08.03.20.54.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: ce6e076764debb36432650838819eee8226935d2
+      sha: 2786323b4013866838b668cacb72a77c5e282f05
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "c48b5cb2c6a41faa7139274429025b44d12132b0"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:f0ed70eaf9906353924fed76ec832ffb1fd01f970908198fcb095e95fcbe279e",
        "repository": "armory/front50-armory",
        "tag": "2021.08.03.20.54.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "2786323b4013866838b668cacb72a77c5e282f05"
      }
    },
    "name": "front50-armory"
  }
}
```