### PR TITLE
chore(cd): update rosco-armory version to 2021.08.03.20.58.27.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:61aeeb7a68daec6f07e28bd1ecd97a8ecb6ef5bc6ca5eb142917db9747dc2603
+      imageId: sha256:23a011eab8ba82bbf5a79cc9e99dfb590fc07cc2f18bf220722e4a96165d66cc
       repository: armory/rosco-armory
-      tag: 2021.07.21.22.38.02.master
+      tag: 2021.08.03.20.58.27.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 42103e208c025e1cba26bc818dd17139458689f4
+      sha: ff3b0cc47cca46f764c81ef2dee9456ad1b48b8f
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "e97c6f17aa22220a7548569378081a4b0877d545"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:23a011eab8ba82bbf5a79cc9e99dfb590fc07cc2f18bf220722e4a96165d66cc",
        "repository": "armory/rosco-armory",
        "tag": "2021.08.03.20.58.27.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "ff3b0cc47cca46f764c81ef2dee9456ad1b48b8f"
      }
    },
    "name": "rosco-armory"
  }
}
```