### PR TITLE
chore(cd): update gate-armory version to 2021.08.03.21.02.18.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:8875b89a66434d9513c79ebac05347b6237b6229baaa9307d68cb686800fe26b
+      imageId: sha256:a758c54fa14eae1ff36a752d1535294879d816b3b17c51ff07878e823f0f3a72
       repository: armory/gate-armory
-      tag: 2021.07.28.18.09.32.master
+      tag: 2021.08.03.21.02.18.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 727765cf9524bd47d6f3c03c0543bf8776d8ce77
+      sha: a7adf5d3e3d4dc7aad9d0b680150fdb36f7a21b3
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "903579c6652aa623b578fe1c9d029ee15bb039d8"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:a758c54fa14eae1ff36a752d1535294879d816b3b17c51ff07878e823f0f3a72",
        "repository": "armory/gate-armory",
        "tag": "2021.08.03.21.02.18.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "a7adf5d3e3d4dc7aad9d0b680150fdb36f7a21b3"
      }
    },
    "name": "gate-armory"
  }
}
```