### PR TITLE
chore(cd): update front50-armory version to 2021.08.04.16.49.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:f0ed70eaf9906353924fed76ec832ffb1fd01f970908198fcb095e95fcbe279e
+      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
       repository: armory/front50-armory
-      tag: 2021.08.03.20.54.51.master
+      tag: 2021.08.04.16.49.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 2786323b4013866838b668cacb72a77c5e282f05
+      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "1e15b2486cc3e200687ea111e80b540b31e56410"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd",
        "repository": "armory/front50-armory",
        "tag": "2021.08.04.16.49.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9"
      }
    },
    "name": "front50-armory"
  }
}
```