### PR TITLE
chore(cd): update kayenta-armory version to 2021.08.04.20.48.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:152413ad8e52ec829141c603ae94f4d65f6d65ce57b457876bbcc6ef2aeadf29
+      imageId: sha256:5e25846ae11eac966f0a2381513288b8e316095ad5ebe55713e0aa3c48edae86
       repository: armory/kayenta-armory
-      tag: 2021.07.21.22.52.32.master
+      tag: 2021.08.04.20.48.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: fd91290091563b96ad5973860e7858ae7d63292e
+      sha: c107287f820e68e8692511243a9c02e5a8569279
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "7b52ba1da3e168c9aa7a53968e9dd20d04f7ecec"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:5e25846ae11eac966f0a2381513288b8e316095ad5ebe55713e0aa3c48edae86",
        "repository": "armory/kayenta-armory",
        "tag": "2021.08.04.20.48.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "c107287f820e68e8692511243a9c02e5a8569279"
      }
    },
    "name": "kayenta-armory"
  }
}
```