### PR TITLE
chore(cd): update orca-armory version to 2021.08.04.21.01.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:4c3b2eb0203e052dd0741e184f4090ab3221c14a085a5a3e5ea89c6c444ecbfd
+      imageId: sha256:b5f70ef720603c6938795511ecb66a64eb19d1cd3ffe048efdc556c9d7a94d56
       repository: armory/orca-armory
-      tag: 2021.08.03.21.11.37.master
+      tag: 2021.08.04.21.01.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 306ff024960bb29051c620a0cab73487a7dfda09
+      sha: 2d6b2691ae8c3b249953eb7f4d97f673d8107242
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "b446a9a827fe9025e3dcf29eb4acba0c597d031f"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:b5f70ef720603c6938795511ecb66a64eb19d1cd3ffe048efdc556c9d7a94d56",
        "repository": "armory/orca-armory",
        "tag": "2021.08.04.21.01.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "2d6b2691ae8c3b249953eb7f4d97f673d8107242"
      }
    },
    "name": "orca-armory"
  }
}
```