### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.04.23.08.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:0d3e704da45a039baa0f06e6f447dcd8f44ef85b43811d6ff4275651be029634
+      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
       repository: armory/clouddriver-armory
-      tag: 2021.07.26.15.42.30.master
+      tag: 2021.08.04.23.08.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 6ab195fce1233629f520cd1091d7435a5f8cd689
+      sha: b1569b8d43da28e329a928aa379d3da3d2662769
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "9ecb52ec1d6f9bc32d73ce78fcc93b40acc4f8ab"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.04.23.08.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b1569b8d43da28e329a928aa379d3da3d2662769"
      }
    },
    "name": "clouddriver-armory"
  }
}
```