### PR TITLE
chore(cd): update echo-armory version to 2021.08.04.20.27.35.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,9 +38,9 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:dae32b7c725d4697a652498fc8b20d2b2deb2f3e58711dd9f9537dc382a13e3f
+      imageId: sha256:4107837a45a59897eed377cf1bb5a9c15d39e38d2200ef321234f33fe3768c3c
       repository: armory/echo-armory
-      tag: 2021.08.04.20.27.35.master
+      tag: 2021.08.04.20.27.35.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "6190984700298ba9e441e7ead624106d6adf127f"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:4107837a45a59897eed377cf1bb5a9c15d39e38d2200ef321234f33fe3768c3c",
        "repository": "armory/echo-armory",
        "tag": "2021.08.04.20.27.35.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "43fa68339d7eeab46396ed84a005d8299243e7ef"
      }
    },
    "name": "echo-armory"
  }
}
```