### PR TITLE
chore(cd): update fiat-armory version to 2021.08.04.22.53.02.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,9 +50,9 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:5af68599d66021042b45df8b2c6339e26736d4749767b0911619d5aa3f6dd79a
+      imageId: sha256:894fc0ec78ba61e2dd1c346c40d31c999a0660e9598c568e57480a85443b1946
       repository: armory/fiat-armory
-      tag: 2021.08.04.22.53.02.master
+      tag: 2021.08.04.22.53.02.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "77dcf5221295779edbf99cf0038d53b2a4e26451"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:894fc0ec78ba61e2dd1c346c40d31c999a0660e9598c568e57480a85443b1946",
        "repository": "armory/fiat-armory",
        "tag": "2021.08.04.22.53.02.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "b51256d70c00653497f0b2f215fcd3721b1a1cdb"
      }
    },
    "name": "fiat-armory"
  }
}
```