### PR TITLE
chore(cd): update orca-armory version to 2021.08.04.23.02.03.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,9 +110,9 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:e4153f47daf9ed8fc20acc45ba43564cc1e014c4b3a415b7641c5a281c185da0
+      imageId: sha256:33536f0a7c0602be2ab56d006157306a6f2daf93cdf97116e19d2c8e38bcbe67
       repository: armory/orca-armory
-      tag: 2021.08.04.23.02.03.master
+      tag: 2021.08.04.23.02.03.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "eb3d65838d3cda53d511f352725f97cca791d086"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:33536f0a7c0602be2ab56d006157306a6f2daf93cdf97116e19d2c8e38bcbe67",
        "repository": "armory/orca-armory",
        "tag": "2021.08.04.23.02.03.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "cfe7f10c6a19d4fd63464db69b12ff7cc2d2e210"
      }
    },
    "name": "orca-armory"
  }
}
```