### PR TITLE
chore(cd): update front50-armory version to 2021.08.04.16.49.32.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,9 +62,9 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:c01f99ade5d135796c27ab989a394d4568c1a26768cc1489e235b09aca2439fa
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.08.04.16.49.32.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "1e15b2486cc3e200687ea111e80b540b31e56410"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c01f99ade5d135796c27ab989a394d4568c1a26768cc1489e235b09aca2439fa",
        "repository": "armory/front50-armory",
        "tag": "2021.08.04.16.49.32.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9"
      }
    },
    "name": "front50-armory"
  }
}
```