### PR TITLE
chore(cd): update gate-armory version to 2021.08.03.21.02.18.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,9 +74,9 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:a758c54fa14eae1ff36a752d1535294879d816b3b17c51ff07878e823f0f3a72
+      imageId: sha256:e20e2ec446313577d362dedd0a9470ee384bc03773d1e07a1303e21b5699d73d
       repository: armory/gate-armory
-      tag: 2021.08.03.21.02.18.master
+      tag: 2021.08.03.21.02.18.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "903579c6652aa623b578fe1c9d029ee15bb039d8"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:e20e2ec446313577d362dedd0a9470ee384bc03773d1e07a1303e21b5699d73d",
        "repository": "armory/gate-armory",
        "tag": "2021.08.03.21.02.18.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "a7adf5d3e3d4dc7aad9d0b680150fdb36f7a21b3"
      }
    },
    "name": "gate-armory"
  }
}
```