### PR TITLE
chore(cd): update igor-armory version to 2021.08.04.22.53.18.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,9 +86,9 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:b5e7b211aea8d18d9324cc3b08900e7617d4da65455eecfa93a5c49be245383b
+      imageId: sha256:1edc089162dbb0632f0d6e1681351bfbf0167f8974ca912104eb149a84062c66
       repository: armory/igor-armory
-      tag: 2021.08.04.22.53.18.master
+      tag: 2021.08.04.22.53.18.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "d72932f7f3dee8231c59dbb1b83cf7eb2d354bf5"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:1edc089162dbb0632f0d6e1681351bfbf0167f8974ca912104eb149a84062c66",
        "repository": "armory/igor-armory",
        "tag": "2021.08.04.22.53.18.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "48a62fe101731b590055728f5ec3b12a2a9e74c0"
      }
    },
    "name": "igor-armory"
  }
}
```