### PR TITLE
chore(cd): update rosco-armory version to 2021.08.03.20.58.27.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,9 +122,9 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:23a011eab8ba82bbf5a79cc9e99dfb590fc07cc2f18bf220722e4a96165d66cc
+      imageId: sha256:f77b6f264bfb9b55695aef140c1792a16039f4af3b719887c63af3d02b996fce
       repository: armory/rosco-armory
-      tag: 2021.08.03.20.58.27.master
+      tag: 2021.08.03.20.58.27.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "e97c6f17aa22220a7548569378081a4b0877d545"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:f77b6f264bfb9b55695aef140c1792a16039f4af3b719887c63af3d02b996fce",
        "repository": "armory/rosco-armory",
        "tag": "2021.08.03.20.58.27.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "ff3b0cc47cca46f764c81ef2dee9456ad1b48b8f"
      }
    },
    "name": "rosco-armory"
  }
}
```