### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.04.23.08.40.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,9 +2,9 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:d0fe009b1f15123085ba7310a7eb9a002c9c0186076990e183a505ba374cf396
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.04.23.08.40.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "9ecb52ec1d6f9bc32d73ce78fcc93b40acc4f8ab"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:d0fe009b1f15123085ba7310a7eb9a002c9c0186076990e183a505ba374cf396",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.04.23.08.40.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b1569b8d43da28e329a928aa379d3da3d2662769"
      }
    },
    "name": "clouddriver-armory"
  }
}
```