### PR TITLE
chore(cd): update deck-armory version to 2021.08.04.18.04.30.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,9 +14,9 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:6a5c53680fd484b3e5a64bb908dad205915ba2e91ecb37fd8eefeda2b72dbe38
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.04.18.04.30.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "a0a4eb52b853b510a81b8068548f0198c7c458b4"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:6a5c53680fd484b3e5a64bb908dad205915ba2e91ecb37fd8eefeda2b72dbe38",
        "repository": "armory/deck-armory",
        "tag": "2021.08.04.18.04.30.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "dc9023cee561f5a3ba23bb5b23687ad422daf56b"
      }
    },
    "name": "deck-armory"
  }
}
```