### PR TITLE
chore(cd): update terraformer version to 2021.07.15.17.11.22.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,9 +134,9 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:647ebb06bdbf9bcd84ffd4f95ad790e9236eaea0258883427d62a9b1fd82940c
+      imageId: sha256:7fdcd079c2fef2ac2474a2fb11d4b86d0e25b98d08b390ca208d19e50745b5ea
       repository: armory/terraformer
-      tag: 2021.07.15.17.11.22.master
+      tag: 2021.07.15.17.11.22.release-2.27.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:7fdcd079c2fef2ac2474a2fb11d4b86d0e25b98d08b390ca208d19e50745b5ea",
        "repository": "armory/terraformer",
        "tag": "2021.07.15.17.11.22.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "717efc9563cee20cb9c37068db976d9598461e1e"
      }
    },
    "name": "terraformer"
  }
}
```