### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.11.00.11.52.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:ad9df1240cfc4e411c07e7fc7f5e3681a1e4c46bd12665e308d329ffc8ef5b5e
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.11.00.11.52.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 04e4d67c1ad9e072f03dbbc92969e80d60b03532
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ace4df87c4307394934423b8df1d8b90354ee1ab"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:ad9df1240cfc4e411c07e7fc7f5e3681a1e4c46bd12665e308d329ffc8ef5b5e",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.11.00.11.52.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "04e4d67c1ad9e072f03dbbc92969e80d60b03532"
      }
    },
    "name": "clouddriver-armory"
  }
}
```