### PR TITLE
chore(cd): update rosco-armory version to 2021.08.12.00.54.05.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:23a011eab8ba82bbf5a79cc9e99dfb590fc07cc2f18bf220722e4a96165d66cc
+      imageId: sha256:08b404fbb99550f4803c2bbd58db3a25f2ad0f3c7abfa017adcc9ee20f4b4672
       repository: armory/rosco-armory
-      tag: 2021.08.03.20.58.27.master
+      tag: 2021.08.12.00.54.05.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: ff3b0cc47cca46f764c81ef2dee9456ad1b48b8f
+      sha: 04d018fcc751b7798fa039597a4eb860564154eb
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "2b06007507d081edd9628aed7b458fef118b558b"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:08b404fbb99550f4803c2bbd58db3a25f2ad0f3c7abfa017adcc9ee20f4b4672",
        "repository": "armory/rosco-armory",
        "tag": "2021.08.12.00.54.05.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "04d018fcc751b7798fa039597a4eb860564154eb"
      }
    },
    "name": "rosco-armory"
  }
}
```