### PR TITLE
chore(cd): update fiat-armory version to 2021.08.12.20.48.26.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:5af68599d66021042b45df8b2c6339e26736d4749767b0911619d5aa3f6dd79a
+      imageId: sha256:f135cf7668497acc9fccca48c6977f77241e79b7a9eb4d0e658a715d35ce9c3f
       repository: armory/fiat-armory
-      tag: 2021.08.04.22.53.02.master
+      tag: 2021.08.12.20.48.26.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b51256d70c00653497f0b2f215fcd3721b1a1cdb
+      sha: 442db8bec0e0c38f3ac82f69275e0889cd4e49ea
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "77dcf5221295779edbf99cf0038d53b2a4e26451"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:f135cf7668497acc9fccca48c6977f77241e79b7a9eb4d0e658a715d35ce9c3f",
        "repository": "armory/fiat-armory",
        "tag": "2021.08.12.20.48.26.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "442db8bec0e0c38f3ac82f69275e0889cd4e49ea"
      }
    },
    "name": "fiat-armory"
  }
}
```