### PR TITLE
chore(cd): update deck-armory version to 2021.08.12.20.59.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:d63458a393bb8c00bfca59c83f12d5e8540722cbae7a9dd3032480a7b704ddba
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.12.20.59.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 2e6810270be174c29dd71e7094575a3d5758aab3
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "b017deb326c206b1ca8fc00036bab3cec8e47266"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:d63458a393bb8c00bfca59c83f12d5e8540722cbae7a9dd3032480a7b704ddba",
        "repository": "armory/deck-armory",
        "tag": "2021.08.12.20.59.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "2e6810270be174c29dd71e7094575a3d5758aab3"
      }
    },
    "name": "deck-armory"
  }
}
```