### PR TITLE
chore(cd): update deck-armory version to 2021.08.12.21.49.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:a0a1a61d5946f4259fd85764bc4d63bc5f6888796e8b0e19f1aba1ad2b96b63c
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.12.21.49.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 4b4eca3fd0046601abba03f40e4388edb40a261c
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "db68932b9859351e4b8d2a1d92779b17ea7ca6a1"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a0a1a61d5946f4259fd85764bc4d63bc5f6888796e8b0e19f1aba1ad2b96b63c",
        "repository": "armory/deck-armory",
        "tag": "2021.08.12.21.49.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "4b4eca3fd0046601abba03f40e4388edb40a261c"
      }
    },
    "name": "deck-armory"
  }
}
```