### PR TITLE
chore(cd): update deck-armory version to 2021.08.13.02.30.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:2e36b8f0820713cdffc2cc0e0a3e462a756c2f49762d74fc07a522f2a02ea31b
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.13.02.30.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 1f1d39105f353563177ec55c66b38b27a20d758c
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "bab8d83005ef7ad6b3c657cdd904392823ac5c0c"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2e36b8f0820713cdffc2cc0e0a3e462a756c2f49762d74fc07a522f2a02ea31b",
        "repository": "armory/deck-armory",
        "tag": "2021.08.13.02.30.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1f1d39105f353563177ec55c66b38b27a20d758c"
      }
    },
    "name": "deck-armory"
  }
}
```