### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.13.14.56.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:4281ebc878475462dba547d3d916c388d096802e4f31f8e9182749223f0ea730
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.13.14.56.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: d35ec2af344c1b37462936cc97742d9c4f35136b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ace4df87c4307394934423b8df1d8b90354ee1ab"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:4281ebc878475462dba547d3d916c388d096802e4f31f8e9182749223f0ea730",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.13.14.56.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d35ec2af344c1b37462936cc97742d9c4f35136b"
      }
    },
    "name": "clouddriver-armory"
  }
}
```