### PR TITLE
chore(cd): update gate-armory version to 2021.08.13.16.55.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:a758c54fa14eae1ff36a752d1535294879d816b3b17c51ff07878e823f0f3a72
+      imageId: sha256:423c8e379a054ae40bb7877c2d5bf205e3e00d095b6b7df44380304686fec871
       repository: armory/gate-armory
-      tag: 2021.08.03.21.02.18.master
+      tag: 2021.08.13.16.55.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: a7adf5d3e3d4dc7aad9d0b680150fdb36f7a21b3
+      sha: 8178e67ff040ddab68d6a939f7bd31b6e7a6bda7
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "79090a418ca45982d801191187026cc51125e3f9"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:423c8e379a054ae40bb7877c2d5bf205e3e00d095b6b7df44380304686fec871",
        "repository": "armory/gate-armory",
        "tag": "2021.08.13.16.55.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "8178e67ff040ddab68d6a939f7bd31b6e7a6bda7"
      }
    },
    "name": "gate-armory"
  }
}
```