### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.15.17.18.29.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:051e7378c84ba9690c520adbbecb0e866492e7bf35bea76a7b52ed54c9a2eb86
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.15.17.18.29.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 08c45d1ff2c6d2bf14d2c13a317fe0f5245af3ac
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "be0bd6d2df545b587f8d2d3637eda1610a393fec"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:051e7378c84ba9690c520adbbecb0e866492e7bf35bea76a7b52ed54c9a2eb86",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.15.17.18.29.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "08c45d1ff2c6d2bf14d2c13a317fe0f5245af3ac"
      }
    },
    "name": "clouddriver-armory"
  }
}
```