### PR TITLE
chore(cd): update deck-armory version to 2021.08.16.17.35.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:c076c56b54d4a85fd16e55811184a5a37055e98bb8ff36dd4fb30f6da34bac87
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.16.17.35.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 00e1d9b812d10380280d9e8809957e1bd7d8fb84
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "e9626d368ddc08626575c57e7e9388c480296bcd"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:c076c56b54d4a85fd16e55811184a5a37055e98bb8ff36dd4fb30f6da34bac87",
        "repository": "armory/deck-armory",
        "tag": "2021.08.16.17.35.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "00e1d9b812d10380280d9e8809957e1bd7d8fb84"
      }
    },
    "name": "deck-armory"
  }
}
```