### PR TITLE
chore(cd): update deck-armory version to 2021.08.16.19.52.02.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:4217a1f8f78f4ba55f5ba916fcd8cbb5403ca33aee171e37530e06c5e7fa7743
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.16.19.52.02.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 48b314b795e4612e4d6990404b8d6b09e6eeb91f
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "c8c6f139283fb4006006ecb38952d6084f8282f0"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:4217a1f8f78f4ba55f5ba916fcd8cbb5403ca33aee171e37530e06c5e7fa7743",
        "repository": "armory/deck-armory",
        "tag": "2021.08.16.19.52.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "48b314b795e4612e4d6990404b8d6b09e6eeb91f"
      }
    },
    "name": "deck-armory"
  }
}
```