### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.17.00.23.29.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:7f48cd44c088693e21116dc446fb87f2fff3a856a1df2131a10c644e36ff2916
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.17.00.23.29.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: d2a2a2122f7df43c4bf417ae8c12e53d5d802087
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "53f974ab75e8b05ab4cec88b9eee20debc9eb072"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:7f48cd44c088693e21116dc446fb87f2fff3a856a1df2131a10c644e36ff2916",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.17.00.23.29.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d2a2a2122f7df43c4bf417ae8c12e53d5d802087"
      }
    },
    "name": "clouddriver-armory"
  }
}
```