### PR TITLE
chore(cd): update deck-armory version to 2021.08.17.20.16.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:bde07a72005fea013c9233b5d5a4f8d55745a27d51ddaf54cfc263f650584303
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.17.20.16.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 79ce5ecd6e043fb2e3316d80e3398065e4aa9f2c
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9f8aa7d253c62bf60d2157c901387dddecf9f1cb"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:bde07a72005fea013c9233b5d5a4f8d55745a27d51ddaf54cfc263f650584303",
        "repository": "armory/deck-armory",
        "tag": "2021.08.17.20.16.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "79ce5ecd6e043fb2e3316d80e3398065e4aa9f2c"
      }
    },
    "name": "deck-armory"
  }
}
```