### PR TITLE
chore(cd): update rosco-armory version to 2021.08.17.23.56.31.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:23a011eab8ba82bbf5a79cc9e99dfb590fc07cc2f18bf220722e4a96165d66cc
+      imageId: sha256:cb2a5fff070eda7f59c00d2fbf522853399d1fca2c1d911ac5f05e38cff4c1d8
       repository: armory/rosco-armory
-      tag: 2021.08.03.20.58.27.master
+      tag: 2021.08.17.23.56.31.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: ff3b0cc47cca46f764c81ef2dee9456ad1b48b8f
+      sha: 8672c91663aee8c4de8f1baf9f3ce6685b2b82e4
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "3534f0255bb95a0434c122c15c705b04d8ce8ac0"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:cb2a5fff070eda7f59c00d2fbf522853399d1fca2c1d911ac5f05e38cff4c1d8",
        "repository": "armory/rosco-armory",
        "tag": "2021.08.17.23.56.31.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "8672c91663aee8c4de8f1baf9f3ce6685b2b82e4"
      }
    },
    "name": "rosco-armory"
  }
}
```