### PR TITLE
chore(cd): update deck-armory version to 2021.08.18.00.19.08.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:f5f2df68021fc598a105a8159234430e20c433793c1eb87d674873e82e9b50f5
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.18.00.19.08.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 07fcfe5e4b6725e37fc018ce35769f3e31823698
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "3121ffa89295dbb252bf4b1f81ba6f1abc0c7e25"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:f5f2df68021fc598a105a8159234430e20c433793c1eb87d674873e82e9b50f5",
        "repository": "armory/deck-armory",
        "tag": "2021.08.18.00.19.08.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "07fcfe5e4b6725e37fc018ce35769f3e31823698"
      }
    },
    "name": "deck-armory"
  }
}
```