### PR TITLE
chore(cd): update deck-armory version to 2021.08.18.00.41.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:2c7682ae4c02eca5fa71a9f1df4b513e5aa3047c6be289304ea440cf6d670bf5
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.08.18.00.41.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 9e0a28b4e35d92177125df22815f2c1c5c09647b
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "847905b44c44fba72009c2f31b288cd0760e5f4b"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2c7682ae4c02eca5fa71a9f1df4b513e5aa3047c6be289304ea440cf6d670bf5",
        "repository": "armory/deck-armory",
        "tag": "2021.08.18.00.41.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "9e0a28b4e35d92177125df22815f2c1c5c09647b"
      }
    },
    "name": "deck-armory"
  }
}
```