### PR TITLE
chore(cd): update fiat-armory version to 2021.08.18.16.29.19.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:5af68599d66021042b45df8b2c6339e26736d4749767b0911619d5aa3f6dd79a
+      imageId: sha256:bd455afd797d2cb1a42d77b5a730b14fdbff54e2d170d1851ad66c0758d714d8
       repository: armory/fiat-armory
-      tag: 2021.08.04.22.53.02.master
+      tag: 2021.08.18.16.29.19.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b51256d70c00653497f0b2f215fcd3721b1a1cdb
+      sha: c5e5b9170aa797487ba46d3a597ab9b6245a52c0
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "3002d367dcda8395a5514aa0dcc66ad850743ca1"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:bd455afd797d2cb1a42d77b5a730b14fdbff54e2d170d1851ad66c0758d714d8",
        "repository": "armory/fiat-armory",
        "tag": "2021.08.18.16.29.19.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "c5e5b9170aa797487ba46d3a597ab9b6245a52c0"
      }
    },
    "name": "fiat-armory"
  }
}
```