### PR TITLE
chore(cd): update orca-armory version to 2021.08.18.16.40.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:e4153f47daf9ed8fc20acc45ba43564cc1e014c4b3a415b7641c5a281c185da0
+      imageId: sha256:7181d8198578ae27bf79c3ec0555899ffed4b01e239b25d8dcf3728d29549d81
       repository: armory/orca-armory
-      tag: 2021.08.04.23.02.03.master
+      tag: 2021.08.18.16.40.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: cfe7f10c6a19d4fd63464db69b12ff7cc2d2e210
+      sha: feb028b9fc89a56b58a6e0d113597f06cce8e5c9
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "7dfd1fa5f7b12cd570a41c854ed61b56da437683"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:7181d8198578ae27bf79c3ec0555899ffed4b01e239b25d8dcf3728d29549d81",
        "repository": "armory/orca-armory",
        "tag": "2021.08.18.16.40.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "feb028b9fc89a56b58a6e0d113597f06cce8e5c9"
      }
    },
    "name": "orca-armory"
  }
}
```