### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.19.16.06.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:d7d19741409795c93a570b9955169e8256868e7ea67893ee0ff9be9d1b69cd90
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.19.16.06.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: eca340d66d6011a9917d4a2c400a441e545d0973
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "979de6792ccd2c26291b51543e1a3832c010474a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:d7d19741409795c93a570b9955169e8256868e7ea67893ee0ff9be9d1b69cd90",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.19.16.06.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "eca340d66d6011a9917d4a2c400a441e545d0973"
      }
    },
    "name": "clouddriver-armory"
  }
}
```