### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.19.16.20.36.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:a44c2ed91628b0e1e8f20bdf67229f2b1ccac874b088f396542de5bc50041e91
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.19.16.20.36.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 5dc677a74a39ea194fee05194b35f95911f7a810
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "233e6da2d630b66cad1d4e2e1fb84a44d3665460"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a44c2ed91628b0e1e8f20bdf67229f2b1ccac874b088f396542de5bc50041e91",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.19.16.20.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5dc677a74a39ea194fee05194b35f95911f7a810"
      }
    },
    "name": "clouddriver-armory"
  }
}
```