### PR TITLE
chore(cd): update orca-armory version to 2021.08.17.09.34.48.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:33536f0a7c0602be2ab56d006157306a6f2daf93cdf97116e19d2c8e38bcbe67
+      imageId: sha256:40c274e23f3e2a5c1d08cf6035e67a772556939e2a22f5b8298c306f66d2d61e
       repository: armory/orca-armory
-      tag: 2021.08.04.23.02.03.release-2.27.x
+      tag: 2021.08.17.09.34.48.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: cfe7f10c6a19d4fd63464db69b12ff7cc2d2e210
+      sha: 45437c668a14a4ef29d0bb44cb76ae36b1a803fe
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c8e4176effdaa92ea7bc0cd586d8e4d27f6894cb"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:40c274e23f3e2a5c1d08cf6035e67a772556939e2a22f5b8298c306f66d2d61e",
        "repository": "armory/orca-armory",
        "tag": "2021.08.17.09.34.48.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "45437c668a14a4ef29d0bb44cb76ae36b1a803fe"
      }
    },
    "name": "orca-armory"
  }
}
```