### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.20.23.37.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:dff95c556ce6c60165025a41c85c29a47c392c49c6420dab928d3afce457eb92
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.20.23.37.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: bfb6c5154dcf6a87eee2e1eac869c959b8e50b70
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "828216b15597dda4ca04f4f2fe59ef924ec01ad5"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:dff95c556ce6c60165025a41c85c29a47c392c49c6420dab928d3afce457eb92",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.20.23.37.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "bfb6c5154dcf6a87eee2e1eac869c959b8e50b70"
      }
    },
    "name": "clouddriver-armory"
  }
}
```