### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.23.17.18.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:f1caf2cd591e79f83cf85193151020b72e2fd1784c783a003dc7baf4c14fd17e
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.23.17.18.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 1e926ce037155f4db43d36ecc89ade3288429c13
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "643dca2e2b9ec5c0239ecb4f7b8f57b0e961a4d3"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:f1caf2cd591e79f83cf85193151020b72e2fd1784c783a003dc7baf4c14fd17e",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.23.17.18.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "1e926ce037155f4db43d36ecc89ade3288429c13"
      }
    },
    "name": "clouddriver-armory"
  }
}
```