### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.23.20.10.17.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:124ded6369f4550422574b2b063978f6fe3a71616bcba4326f177a414f9f5185
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.23.20.10.17.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 25ae84708da8ee60fe3c4cc1998ec9e1cd2827cb
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6427be720cc2f94df635928b0ef6cd899f4bca76"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:124ded6369f4550422574b2b063978f6fe3a71616bcba4326f177a414f9f5185",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.23.20.10.17.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "25ae84708da8ee60fe3c4cc1998ec9e1cd2827cb"
      }
    },
    "name": "clouddriver-armory"
  }
}
```