### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.23.23.23.52.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:d0fe009b1f15123085ba7310a7eb9a002c9c0186076990e183a505ba374cf396
+      imageId: sha256:0a3d2b368e070fd17f58674f04db81264e4ce9341970388e76c5114e93cc4ae5
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.release-2.27.x
+      tag: 2021.08.23.23.23.52.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: d63ba5ea7b2eca192bd16d6063e84a8fc9ee6442
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "9ecb52ec1d6f9bc32d73ce78fcc93b40acc4f8ab"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0a3d2b368e070fd17f58674f04db81264e4ce9341970388e76c5114e93cc4ae5",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.23.23.23.52.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d63ba5ea7b2eca192bd16d6063e84a8fc9ee6442"
      }
    },
    "name": "clouddriver-armory"
  }
}
```