### PR TITLE
chore(cd): update igor-armory version to 2021.08.23.23.39.32.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:1edc089162dbb0632f0d6e1681351bfbf0167f8974ca912104eb149a84062c66
+      imageId: sha256:e8f9c0c28875e761473c6ee608942b272b35f9deb4dc5ec916d5bef96d4fecfb
       repository: armory/igor-armory
-      tag: 2021.08.04.22.53.18.release-2.27.x
+      tag: 2021.08.23.23.39.32.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 48a62fe101731b590055728f5ec3b12a2a9e74c0
+      sha: 003ea7be331f05a6f207eaa0c247f494054f428c
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "d72932f7f3dee8231c59dbb1b83cf7eb2d354bf5"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:e8f9c0c28875e761473c6ee608942b272b35f9deb4dc5ec916d5bef96d4fecfb",
        "repository": "armory/igor-armory",
        "tag": "2021.08.23.23.39.32.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "003ea7be331f05a6f207eaa0c247f494054f428c"
      }
    },
    "name": "igor-armory"
  }
}
```