### PR TITLE
chore(cd): update front50-armory version to 2021.08.24.13.05.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:9ac7dd7cebc001d3b098b9e4bb1710ed349387c59f8b9f572d05bb2ccead7594
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.08.24.13.05.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: e8a48a65b85dfc7c55225c12999d13d577e77b7e
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "6013f49c05173abe1e28829d6d80408f73546afd"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:9ac7dd7cebc001d3b098b9e4bb1710ed349387c59f8b9f572d05bb2ccead7594",
        "repository": "armory/front50-armory",
        "tag": "2021.08.24.13.05.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "e8a48a65b85dfc7c55225c12999d13d577e77b7e"
      }
    },
    "name": "front50-armory"
  }
}
```