### PR TITLE
chore(cd): update kayenta-armory version to 2021.08.24.00.40.05.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:0f44b46ebc374d8c812a08466d98b2343493e986822daba971c8274c995f7b41
+      imageId: sha256:0d6339a5bc2dc0d2609564f6c6af1d67c5f42c1527505bf47ce9e2f74a058b13
       repository: armory/kayenta-armory
-      tag: 2021.07.06.22.22.40.release-2.26.x
+      tag: 2021.08.24.00.40.05.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 1d27eaf7f8f9d38ac05877fce7b0f740e4e7de39
+      sha: 4f668d1297a5d205d516667c1af6902d0d9f380f
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:0d6339a5bc2dc0d2609564f6c6af1d67c5f42c1527505bf47ce9e2f74a058b13",
        "repository": "armory/kayenta-armory",
        "tag": "2021.08.24.00.40.05.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "4f668d1297a5d205d516667c1af6902d0d9f380f"
      }
    },
    "name": "kayenta-armory"
  }
}
```