### PR TITLE
chore(cd): update front50-armory version to 2021.08.24.19.28.32.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:c01f99ade5d135796c27ab989a394d4568c1a26768cc1489e235b09aca2439fa
+      imageId: sha256:017d40cb5ed0a2aa5432c29a1039a974f9cd14b4c0c0c6650fb0ce6381cce9ce
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.release-2.27.x
+      tag: 2021.08.24.19.28.32.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: bcafedc1fa3ddbb2d4dcbab909f0c1c9800b0715
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "1e15b2486cc3e200687ea111e80b540b31e56410"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:017d40cb5ed0a2aa5432c29a1039a974f9cd14b4c0c0c6650fb0ce6381cce9ce",
        "repository": "armory/front50-armory",
        "tag": "2021.08.24.19.28.32.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "bcafedc1fa3ddbb2d4dcbab909f0c1c9800b0715"
      }
    },
    "name": "front50-armory"
  }
}
```