### PR TITLE
chore(cd): update orca-armory version to 2021.08.25.21.53.41.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:e4153f47daf9ed8fc20acc45ba43564cc1e014c4b3a415b7641c5a281c185da0
+      imageId: sha256:8d0955154f1e32d48002d93aae25204b6ccf3b4435a2dd441e2ebf53ffe37540
       repository: armory/orca-armory
-      tag: 2021.08.04.23.02.03.master
+      tag: 2021.08.25.21.53.41.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: cfe7f10c6a19d4fd63464db69b12ff7cc2d2e210
+      sha: 970450545c30cfd23c8b8b3832a01cf1a2f83aef
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:8d0955154f1e32d48002d93aae25204b6ccf3b4435a2dd441e2ebf53ffe37540",
        "repository": "armory/orca-armory",
        "tag": "2021.08.25.21.53.41.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "970450545c30cfd23c8b8b3832a01cf1a2f83aef"
      }
    },
    "name": "orca-armory"
  }
}
```