### PR TITLE
chore(cd): update deck-armory version to 2021.08.26.04.30.16.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:c5daf27daad24b0064655ecbb23debb46040d5bc86b1fbd9a1e1af0e61d91d22
+      imageId: sha256:075563173e0a829bfcab9559610c066142d83b9582dc061364bbd6e9b31a8223
       repository: armory/deck-armory
-      tag: 2021.08.24.22.45.10.release-2.26.x
+      tag: 2021.08.26.04.30.16.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 87d1df6c5bfe4381c73a41121d8906bd2d89f42a
+      sha: a2296787ab03efc53c85d03cbf8eecddedab6094
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:075563173e0a829bfcab9559610c066142d83b9582dc061364bbd6e9b31a8223",
        "repository": "armory/deck-armory",
        "tag": "2021.08.26.04.30.16.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "a2296787ab03efc53c85d03cbf8eecddedab6094"
      }
    },
    "name": "deck-armory"
  }
}
```