### PR TITLE
chore(cd): update terraformer version to 2021.08.26.18.53.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:647ebb06bdbf9bcd84ffd4f95ad790e9236eaea0258883427d62a9b1fd82940c
+      imageId: sha256:fe1bdfbe1cde3e9a7f6f7294838945e156ec73310bc3413e119c86bd45ddf00b
       repository: armory/terraformer
-      tag: 2021.07.15.17.11.22.master
+      tag: 2021.08.26.18.53.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 717efc9563cee20cb9c37068db976d9598461e1e
+      sha: 1f72bee9de00e41294c947d406b292acd9a4df2a


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:fe1bdfbe1cde3e9a7f6f7294838945e156ec73310bc3413e119c86bd45ddf00b",
        "repository": "armory/terraformer",
        "tag": "2021.08.26.18.53.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "1f72bee9de00e41294c947d406b292acd9a4df2a"
      }
    },
    "name": "terraformer"
  }
}
```