### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.27.22.15.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:a392451e19853d736ba32133d1b6f4c515a0507e43f2105ba99e2c7d37841075
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.27.22.15.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 26485bc382428feaa042eef6c3b18f733564ae75
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "37d87f5e6f640c5bbae9a7605917dbba4dcf3aeb"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a392451e19853d736ba32133d1b6f4c515a0507e43f2105ba99e2c7d37841075",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.27.22.15.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "26485bc382428feaa042eef6c3b18f733564ae75"
      }
    },
    "name": "clouddriver-armory"
  }
}
```