### PR TITLE
chore(cd): update fiat-armory version to 2021.08.30.16.13.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:5af68599d66021042b45df8b2c6339e26736d4749767b0911619d5aa3f6dd79a
+      imageId: sha256:ba9f861193f2738eac920f1893dc94b7876678902e667246895b9a42ab3bff25
       repository: armory/fiat-armory
-      tag: 2021.08.04.22.53.02.master
+      tag: 2021.08.30.16.13.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b51256d70c00653497f0b2f215fcd3721b1a1cdb
+      sha: 0de27a580004f7c1451b2fdcf0d8e329dd261365
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "5ea6138d997d9793ba392f4ac29d4d2076151855"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:ba9f861193f2738eac920f1893dc94b7876678902e667246895b9a42ab3bff25",
        "repository": "armory/fiat-armory",
        "tag": "2021.08.30.16.13.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "0de27a580004f7c1451b2fdcf0d8e329dd261365"
      }
    },
    "name": "fiat-armory"
  }
}
```