### PR TITLE
chore(cd): update orca-armory version to 2021.08.30.16.25.56.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:e4153f47daf9ed8fc20acc45ba43564cc1e014c4b3a415b7641c5a281c185da0
+      imageId: sha256:cabdc04a7cb407b33daafa7ff7159e9cbabfe712100e00ad7a1763257d3f823a
       repository: armory/orca-armory
-      tag: 2021.08.04.23.02.03.master
+      tag: 2021.08.30.16.25.56.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: cfe7f10c6a19d4fd63464db69b12ff7cc2d2e210
+      sha: 29c089a71b3a5303222e44f5ac3c45229befb46b
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "221dcd9f356e9a2890d7da61d02a84fe71ca37ea"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:cabdc04a7cb407b33daafa7ff7159e9cbabfe712100e00ad7a1763257d3f823a",
        "repository": "armory/orca-armory",
        "tag": "2021.08.30.16.25.56.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "29c089a71b3a5303222e44f5ac3c45229befb46b"
      }
    },
    "name": "orca-armory"
  }
}
```