### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.30.16.31.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:99497ed48a154e0f4308b2d741388130d9bc255c2515078c0b429b5cd6d28540
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.30.16.31.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: ed66dd7b4dc6832b3d9bfa63d55cc33e488d1dc2
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "850042289868fe64a364e37b60a267f2f07d955a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:99497ed48a154e0f4308b2d741388130d9bc255c2515078c0b429b5cd6d28540",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.30.16.31.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ed66dd7b4dc6832b3d9bfa63d55cc33e488d1dc2"
      }
    },
    "name": "clouddriver-armory"
  }
}
```