### PR TITLE
chore(cd): update fiat-armory version to 2021.08.30.16.54.42.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:5af68599d66021042b45df8b2c6339e26736d4749767b0911619d5aa3f6dd79a
+      imageId: sha256:7dac711f6aee81bff85982f26803d173dc881fadd6692ae272221baa753bb08d
       repository: armory/fiat-armory
-      tag: 2021.08.04.22.53.02.master
+      tag: 2021.08.30.16.54.42.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b51256d70c00653497f0b2f215fcd3721b1a1cdb
+      sha: af6921754cc607afb390551de7c23cd3894410c3
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "3b01ca9a4aa43d506558a53ac6d5162cd8f51506"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:7dac711f6aee81bff85982f26803d173dc881fadd6692ae272221baa753bb08d",
        "repository": "armory/fiat-armory",
        "tag": "2021.08.30.16.54.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "af6921754cc607afb390551de7c23cd3894410c3"
      }
    },
    "name": "fiat-armory"
  }
}
```