### PR TITLE
chore(cd): update echo-armory version to 2021.08.30.16.53.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:dae32b7c725d4697a652498fc8b20d2b2deb2f3e58711dd9f9537dc382a13e3f
+      imageId: sha256:3dc74bb24e361d28cdedafa30c4b159c62faebab2b1f88950dac922c2a3c8dac
       repository: armory/echo-armory
-      tag: 2021.08.04.20.27.35.master
+      tag: 2021.08.30.16.53.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 43fa68339d7eeab46396ed84a005d8299243e7ef
+      sha: 0fbb6a608444168bc5425031dd9938ca564d35b5
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "f9b6d0366a8cc0b04cee7e92e013bbd8be16b69f"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:3dc74bb24e361d28cdedafa30c4b159c62faebab2b1f88950dac922c2a3c8dac",
        "repository": "armory/echo-armory",
        "tag": "2021.08.30.16.53.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "0fbb6a608444168bc5425031dd9938ca564d35b5"
      }
    },
    "name": "echo-armory"
  }
}
```