### PR TITLE
chore(cd): update rosco-armory version to 2021.08.30.16.58.05.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:23a011eab8ba82bbf5a79cc9e99dfb590fc07cc2f18bf220722e4a96165d66cc
+      imageId: sha256:8179bea6d5e4ebcc8b917337ad84342e5ad377c6f854e1c49bda0703a1a48adf
       repository: armory/rosco-armory
-      tag: 2021.08.03.20.58.27.master
+      tag: 2021.08.30.16.58.05.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: ff3b0cc47cca46f764c81ef2dee9456ad1b48b8f
+      sha: 45083dbe50b64e8b589edf72dcf276e2054f9e29
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "8e6117ee702ce3e3ca693a1f695df5f893ca6455"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:8179bea6d5e4ebcc8b917337ad84342e5ad377c6f854e1c49bda0703a1a48adf",
        "repository": "armory/rosco-armory",
        "tag": "2021.08.30.16.58.05.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "45083dbe50b64e8b589edf72dcf276e2054f9e29"
      }
    },
    "name": "rosco-armory"
  }
}
```