### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.30.17.15.56.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:b7d1a52dc204a37f8f50a536d387bd22751bf6f46449e78bdda5c0480cadc382
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.30.17.15.56.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 79ca77e4bdbf1124b8bf508fabcba4d1f8584e9b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b820dd1d753f5e0ada8d005abb30fd08b7ca7c65"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:b7d1a52dc204a37f8f50a536d387bd22751bf6f46449e78bdda5c0480cadc382",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.30.17.15.56.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "79ca77e4bdbf1124b8bf508fabcba4d1f8584e9b"
      }
    },
    "name": "clouddriver-armory"
  }
}
```