### PR TITLE
chore(cd): update clouddriver-armory version to 2021.08.30.20.20.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:733ce49751f9d3cdc8cb17dbeeaf7954336eb8d097c1ae9bb6fa3b6f8c0438cf
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.08.30.20.20.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 15705285aef92d546c2502b7176647d8bed3dc1e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "62325f922533d9e96b35d88698959def4ad517b5"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:733ce49751f9d3cdc8cb17dbeeaf7954336eb8d097c1ae9bb6fa3b6f8c0438cf",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.08.30.20.20.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "15705285aef92d546c2502b7176647d8bed3dc1e"
      }
    },
    "name": "clouddriver-armory"
  }
}
```