### PR TITLE
chore(cd): update front50-armory version to 2021.08.30.23.25.35.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:47e21fc1528a417966ae349a18f5d5c46efeca85e111263740598e9bf2f8bdbd
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.08.30.23.25.35.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 14332a95f596da3ece504810bf18d7782ca2e7d1
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "2bae7c8cfe83242cb323516fc14ebfcb0b642ba0"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:47e21fc1528a417966ae349a18f5d5c46efeca85e111263740598e9bf2f8bdbd",
        "repository": "armory/front50-armory",
        "tag": "2021.08.30.23.25.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "14332a95f596da3ece504810bf18d7782ca2e7d1"
      }
    },
    "name": "front50-armory"
  }
}
```