### PR TITLE
chore(cd): update gate-armory version to 2021.08.31.15.20.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:a758c54fa14eae1ff36a752d1535294879d816b3b17c51ff07878e823f0f3a72
+      imageId: sha256:9fb351f39144647e031e3ee97989d1528663761bb6288443e4e426a3798d143e
       repository: armory/gate-armory
-      tag: 2021.08.03.21.02.18.master
+      tag: 2021.08.31.15.20.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: a7adf5d3e3d4dc7aad9d0b680150fdb36f7a21b3
+      sha: ffb65a3a1be1bf76e8dc63e5833e300c3b4c7abe
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "26607504dc1c02c4a4cf678e062c057a09ecf525"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:9fb351f39144647e031e3ee97989d1528663761bb6288443e4e426a3798d143e",
        "repository": "armory/gate-armory",
        "tag": "2021.08.31.15.20.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "ffb65a3a1be1bf76e8dc63e5833e300c3b4c7abe"
      }
    },
    "name": "gate-armory"
  }
}
```