### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.01.15.34.17.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:561b84eb88929857464a2343f1fa38c0200d6cb5038fcfca296a68fd834e1f18
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.01.15.34.17.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 318418c6a932d764ec7c706661883abdbec17189
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "1de3a92404279f60ead9b978a62417e4025450d5"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:561b84eb88929857464a2343f1fa38c0200d6cb5038fcfca296a68fd834e1f18",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.01.15.34.17.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "318418c6a932d764ec7c706661883abdbec17189"
      }
    },
    "name": "clouddriver-armory"
  }
}
```