### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.02.17.41.23.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:d542809c09e969894b42889dc4d5f2edd3544192b885d48e18ab0d86917e2ae5
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.02.17.41.23.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 922a7255ad8dacd20f772e46fd735533ce06c457
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0fb49ee377c5b352c791f7230ba35323e22ee0d1"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:d542809c09e969894b42889dc4d5f2edd3544192b885d48e18ab0d86917e2ae5",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.02.17.41.23.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "922a7255ad8dacd20f772e46fd735533ce06c457"
      }
    },
    "name": "clouddriver-armory"
  }
}
```