### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.03.00.36.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:0f6369cdc056c5d06cc16722e40d10964660e721291182e601d56405f166fd0d
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.03.00.36.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 3cb138edc46101ae00f41a2f96c179326a37cd3c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "4d4e01084ac5259792020e419b1af7686ab38019"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0f6369cdc056c5d06cc16722e40d10964660e721291182e601d56405f166fd0d",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.03.00.36.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3cb138edc46101ae00f41a2f96c179326a37cd3c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```