### PR TITLE
chore(cd): update front50-armory version to 2021.09.03.16.20.34.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:0f7bd3458f30ada2381645413724a2dc0de0f131a428e686d015e9da427de9ed
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.09.03.16.20.34.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 65b092bb9b896fe4d9458e16566b2f23f5eec662
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "ad51bf1b8e46fb133a0d6a096aac05a952a08d60"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:0f7bd3458f30ada2381645413724a2dc0de0f131a428e686d015e9da427de9ed",
        "repository": "armory/front50-armory",
        "tag": "2021.09.03.16.20.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "65b092bb9b896fe4d9458e16566b2f23f5eec662"
      }
    },
    "name": "front50-armory"
  }
}
```