### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.03.16.42.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:7a71875812d926d1666f7357b657c49f653cddf571f9c7ac59baa50b68184f99
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.03.16.42.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: f6eed5ded5ac51cfdfd8473224d4208aa2ee6074
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "30b998895caf55f3367cd2dafa840a74b4a34c50"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:7a71875812d926d1666f7357b657c49f653cddf571f9c7ac59baa50b68184f99",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.03.16.42.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f6eed5ded5ac51cfdfd8473224d4208aa2ee6074"
      }
    },
    "name": "clouddriver-armory"
  }
}
```