### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.07.17.03.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:735a90e5593cc4628e269fc986bb08cc2d529f535bf4bbeabf46b0aefd9b8f4a
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.07.17.03.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 106cc8e7322ad2f78fd524dc47fa8d92886b06f3
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "1cbf37007434ba4a3ac312b33e1e2ed577b54fd9"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:735a90e5593cc4628e269fc986bb08cc2d529f535bf4bbeabf46b0aefd9b8f4a",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.07.17.03.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "106cc8e7322ad2f78fd524dc47fa8d92886b06f3"
      }
    },
    "name": "clouddriver-armory"
  }
}
```