### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.07.17.41.08.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:56468acd890c0b38d37dc9add61b0da606037b07a6e1c1d558b31c8384712ef6
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.07.17.41.08.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 1c0b4700fc6ae01eed8bde98538e1be96919b380
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "9efcf95b34beae11e8837e3e469065b066e2c4bd"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:56468acd890c0b38d37dc9add61b0da606037b07a6e1c1d558b31c8384712ef6",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.07.17.41.08.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "1c0b4700fc6ae01eed8bde98538e1be96919b380"
      }
    },
    "name": "clouddriver-armory"
  }
}
```