### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.08.00.38.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:8149d154e85b03c7599f07ebd1784c5f443db2574cc16aa7acfdcc18cf5711bd
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.08.00.38.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: b77f88430630fe3d60e11655a2e76fb96d8a8046
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a62d438a7a82842e7a2b63a3c17806a97f9270c6"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8149d154e85b03c7599f07ebd1784c5f443db2574cc16aa7acfdcc18cf5711bd",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.08.00.38.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b77f88430630fe3d60e11655a2e76fb96d8a8046"
      }
    },
    "name": "clouddriver-armory"
  }
}
```