### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.08.05.05.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:3f5f7e28a91e2775e954445814ae74aa6e437a09065a76329e57d8c9e0447944
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.08.05.05.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: e81c423181206df6ff2bf53ca0dc7fba0897348f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6a52f62ca12120b34c1f59acf1931816c8885f76"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3f5f7e28a91e2775e954445814ae74aa6e437a09065a76329e57d8c9e0447944",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.08.05.05.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e81c423181206df6ff2bf53ca0dc7fba0897348f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```