### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.08.16.57.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:be2c740d25fbb18933ed0c05c6775ccd3495584225c2630bf733a5f87efcc624
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.08.16.57.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 71f4e152e645efb987c615025a8b21b7edcb7f80
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "e5d27bc032d0bb15c0b4c6ab8b8b03c0b97b6ac3"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:be2c740d25fbb18933ed0c05c6775ccd3495584225c2630bf733a5f87efcc624",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.08.16.57.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "71f4e152e645efb987c615025a8b21b7edcb7f80"
      }
    },
    "name": "clouddriver-armory"
  }
}
```