### PR TITLE
chore(cd): update orca-armory version to 2021.09.09.20.00.11.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:f3fffaa0da0852cae28e755c2e3ee15e1b0cd6bbf74ed29ac0982a4b88ef0e55
+      imageId: sha256:7ad48ffcdcc55290edabab11a78039b456722f0e35e2183d7d9cdaa6091e60e6
       repository: armory/orca-armory
-      tag: 2021.08.23.22.49.49.release-2.27.x
+      tag: 2021.09.09.20.00.11.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4b2ca3de1b99fc5e48f70a174917a9ea420f72d5
+      sha: 658d6de1e212cbf30181dd30e86283bccf481004
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c8e4176effdaa92ea7bc0cd586d8e4d27f6894cb"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:7ad48ffcdcc55290edabab11a78039b456722f0e35e2183d7d9cdaa6091e60e6",
        "repository": "armory/orca-armory",
        "tag": "2021.09.09.20.00.11.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "658d6de1e212cbf30181dd30e86283bccf481004"
      }
    },
    "name": "orca-armory"
  }
}
```