### PR TITLE
chore(cd): update front50-armory version to 2021.09.09.20.05.16.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:78ec54072df10a537704d2b14b63f1976666b32a68180855ea174a333d065eb6
+      imageId: sha256:bce8c35e199b4e625aa0f451ac1c1752bfefee45875430cf8f0ed83d13ddd4b0
       repository: armory/front50-armory
-      tag: 2021.08.28.01.43.44.release-2.26.x
+      tag: 2021.09.09.20.05.16.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 8bdd585434b9bde9834bf580d96fdd42d12dc933
+      sha: ba5b33e616e51dc0e655f40da18277c9434ca5fe
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:bce8c35e199b4e625aa0f451ac1c1752bfefee45875430cf8f0ed83d13ddd4b0",
        "repository": "armory/front50-armory",
        "tag": "2021.09.09.20.05.16.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "ba5b33e616e51dc0e655f40da18277c9434ca5fe"
      }
    },
    "name": "front50-armory"
  }
}
```