### PR TITLE
chore(cd): update deck-armory version to 2021.09.09.19.58.41.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:075563173e0a829bfcab9559610c066142d83b9582dc061364bbd6e9b31a8223
+      imageId: sha256:3cf245bc2346c8f7fa036d39bb04a5f17aa3aad74e13b164d4072485d02117ce
       repository: armory/deck-armory
-      tag: 2021.08.26.04.30.16.release-2.26.x
+      tag: 2021.09.09.19.58.41.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: a2296787ab03efc53c85d03cbf8eecddedab6094
+      sha: b31998c9e3132417354fd8500c7faf55339268b2
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3cf245bc2346c8f7fa036d39bb04a5f17aa3aad74e13b164d4072485d02117ce",
        "repository": "armory/deck-armory",
        "tag": "2021.09.09.19.58.41.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "b31998c9e3132417354fd8500c7faf55339268b2"
      }
    },
    "name": "deck-armory"
  }
}
```