### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.09.21.18.35.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:dc1d1a58c5047698ded36cdee7f8b4a120112820cbf218b5f6b81736517ccacc
+      imageId: sha256:1e8b4d30677ac5fa28af01dcb3e6dfbecf4319ce96c247f6b895d36fb42f2e3a
       repository: armory/clouddriver-armory
-      tag: 2021.09.09.20.50.45.release-2.27.x
+      tag: 2021.09.09.21.18.35.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 7b992d387a7fa8fd9258d571c8b59081f08a6775
+      sha: 5c2ce556104161a6f2076516a5508d8139fb5674
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "5a10f99aaf9474b88fa06299550f22b889384634"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1e8b4d30677ac5fa28af01dcb3e6dfbecf4319ce96c247f6b895d36fb42f2e3a",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.09.21.18.35.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5c2ce556104161a6f2076516a5508d8139fb5674"
      }
    },
    "name": "clouddriver-armory"
  }
}
```