### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.09.21.38.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:2dfbf9ae024c035b29fdbf778dd315ba65b6272bd4af301c8674091fbc458242
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.09.21.38.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: b34a1ee51d072154d173f641ead535cf2f7c0def
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f99fe9258a42507e1f6c163bd64a380c9ffe7d10"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2dfbf9ae024c035b29fdbf778dd315ba65b6272bd4af301c8674091fbc458242",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.09.21.38.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b34a1ee51d072154d173f641ead535cf2f7c0def"
      }
    },
    "name": "clouddriver-armory"
  }
}
```