### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.09.22.08.51.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:c1b53cec74514c7a531e706196b5a298f479f3fe4e2ea3237cf00112e1816388
+      imageId: sha256:143abae132c0c3a2d748dba71abfac98bd8ae8adf75dacbe386dfee1ef798516
       repository: armory/clouddriver-armory
-      tag: 2021.09.09.20.09.08.release-2.26.x
+      tag: 2021.09.09.22.08.51.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 180a2dfa656475a84722709ccf3b066910517c76
+      sha: 259a103f757f3bdc3cb94c754f31a294ceea3737
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "79f34a4c68c7e9041f56244e7a0eae50662a394a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:143abae132c0c3a2d748dba71abfac98bd8ae8adf75dacbe386dfee1ef798516",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.09.22.08.51.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "259a103f757f3bdc3cb94c754f31a294ceea3737"
      }
    },
    "name": "clouddriver-armory"
  }
}
```