### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.09.23.47.45.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:30b704af444b42ecdb012ec40d86b8989e5b4aedb81f875b7f49a7a8fbd552cb
+      imageId: sha256:937face3a3384152bb559dacb9e8807222fa54baf168431caf4bea396aa5c0e8
       repository: armory/clouddriver-armory
-      tag: 2021.09.09.22.10.32.release-2.27.x
+      tag: 2021.09.09.23.47.45.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: a5afacbabc78eb0641c6abbc5a4aef77ddb05af7
+      sha: 65db489d99514e3a4232225847534bb3bd07d131
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a2d6a6e712d4e6e2fc45d6c0cf3bbba8039a7104"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:937face3a3384152bb559dacb9e8807222fa54baf168431caf4bea396aa5c0e8",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.09.23.47.45.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "65db489d99514e3a4232225847534bb3bd07d131"
      }
    },
    "name": "clouddriver-armory"
  }
}
```