### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.13.19.39.52.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:0092f7f6d45fdb4b6c61a4a4fbb8fe3ed83feae2d45cdd92357d5f021186e680
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.13.19.39.52.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: cfd3c3a3a40664f45d766d1bd7fd63537711d1a8
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0dff108c6fcc4741adbb3ed6cb19f8e7da427150"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0092f7f6d45fdb4b6c61a4a4fbb8fe3ed83feae2d45cdd92357d5f021186e680",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.13.19.39.52.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "cfd3c3a3a40664f45d766d1bd7fd63537711d1a8"
      }
    },
    "name": "clouddriver-armory"
  }
}
```