### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.14.20.29.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:1c61de97a421cad38384ccfd0b5dfd531117cdc1be7d120f703d813dc3687d81
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.14.20.29.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 0198458e4149c319b559b54460ada7f90c2d8a8f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b4444050edd54441ec5bc4d3ed8739cdae150c51"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1c61de97a421cad38384ccfd0b5dfd531117cdc1be7d120f703d813dc3687d81",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.14.20.29.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "0198458e4149c319b559b54460ada7f90c2d8a8f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```