### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.15.16.28.49.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:1fd81315ee8ad4e8566f6fa127ad6c426e037b3d9a66092da2856168f9b54876
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.15.16.28.49.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 1ac5f33fa1bf3cdec93ab4aa26bf51cba1bc50bd
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "18e53a0cfd51146c858708f00b56c15db069b2cc"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1fd81315ee8ad4e8566f6fa127ad6c426e037b3d9a66092da2856168f9b54876",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.15.16.28.49.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "1ac5f33fa1bf3cdec93ab4aa26bf51cba1bc50bd"
      }
    },
    "name": "clouddriver-armory"
  }
}
```