### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.15.17.02.20.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:a91849c0c6223872de14faa69570681cc7a14bc2b300f2f5eeed23b2158b4d01
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.15.17.02.20.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: f17d4e14834297979263a2ee033eb28d817308ae
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "204cae49b81fe1e0a65451d85a6bfbe0da7951fe"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a91849c0c6223872de14faa69570681cc7a14bc2b300f2f5eeed23b2158b4d01",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.15.17.02.20.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f17d4e14834297979263a2ee033eb28d817308ae"
      }
    },
    "name": "clouddriver-armory"
  }
}
```