### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.15.23.25.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:3312f6c5d33ec78564701015771ba45bb089c082e414126ee9817af112b1c78d
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.15.23.25.58.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: f3cbf053538bdc857277c648ac0a3c5379c10b96
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "aecbc9682f9a8b214bc587700dbcc11e5dca6e5f"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3312f6c5d33ec78564701015771ba45bb089c082e414126ee9817af112b1c78d",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.15.23.25.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f3cbf053538bdc857277c648ac0a3c5379c10b96"
      }
    },
    "name": "clouddriver-armory"
  }
}
```