### PR TITLE
chore(cd): update terraformer version to 2021.09.17.18.01.39.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:f10d35de2141852bc9e6d60bc53ec08fa03ed05312ae78b47d6b9a2607ac314d
+      imageId: sha256:eb4e22e641d9dc590f048ba0219c6a2f5ddd9b32bb00efeb74608cffbe0b0d6d
       repository: armory/terraformer
-      tag: 2021.08.26.20.41.01.release-2.26.x
+      tag: 2021.09.17.18.01.39.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: d20745f6ac1fb87b876dbd255b0b26004fb0341a
+      sha: 2dc177734c1445252dfeb3b8353ce94596c8a4c3


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:eb4e22e641d9dc590f048ba0219c6a2f5ddd9b32bb00efeb74608cffbe0b0d6d",
        "repository": "armory/terraformer",
        "tag": "2021.09.17.18.01.39.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "2dc177734c1445252dfeb3b8353ce94596c8a4c3"
      }
    },
    "name": "terraformer"
  }
}
```