### PR TITLE
chore(cd): update terraformer version to 2021.09.17.18.01.42.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:647ebb06bdbf9bcd84ffd4f95ad790e9236eaea0258883427d62a9b1fd82940c
+      imageId: sha256:d5c4b917e183816f258909b7b824b9a4efcde751847f3d03ca8c15a2e8dddcbb
       repository: armory/terraformer
-      tag: 2021.07.15.17.11.22.master
+      tag: 2021.09.17.18.01.42.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 717efc9563cee20cb9c37068db976d9598461e1e
+      sha: 3833f1321ff9744ec33b5a0d06d29c4e55e22f63


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:d5c4b917e183816f258909b7b824b9a4efcde751847f3d03ca8c15a2e8dddcbb",
        "repository": "armory/terraformer",
        "tag": "2021.09.17.18.01.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "3833f1321ff9744ec33b5a0d06d29c4e55e22f63"
      }
    },
    "name": "terraformer"
  }
}
```