### PR TITLE
chore(cd): update front50-armory version to 2021.09.21.18.07.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:5df268780188961cfab40e6e83bc3fa61b91027b0d4faddcb6e392086e74439e
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.09.21.18.07.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 8d14d389f114512871ff0711f6ba616ba837a951
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "bbd8fd7fbf02be2e70a4603a370c35e703d29168"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:5df268780188961cfab40e6e83bc3fa61b91027b0d4faddcb6e392086e74439e",
        "repository": "armory/front50-armory",
        "tag": "2021.09.21.18.07.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "8d14d389f114512871ff0711f6ba616ba837a951"
      }
    },
    "name": "front50-armory"
  }
}
```