### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.23.00.32.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:290c2ed48e141d28f8e09542b97fdebb4012eb4826d66b87f4696df89b3bb920
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.23.00.32.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 3ad9fc77d61f4a14881f185d4d958af7da4b1fcb
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "58ab154b0ec0d62772201b5b319af349498a4e3f"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:290c2ed48e141d28f8e09542b97fdebb4012eb4826d66b87f4696df89b3bb920",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.23.00.32.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3ad9fc77d61f4a14881f185d4d958af7da4b1fcb"
      }
    },
    "name": "clouddriver-armory"
  }
}
```