### PR TITLE
chore(cd): update deck-armory version to 2021.09.23.01.01.09.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:3cf245bc2346c8f7fa036d39bb04a5f17aa3aad74e13b164d4072485d02117ce
+      imageId: sha256:25fe36a2947dd2e46334d6c0fb29841305ef4292f830f547c47dddf0d4f97e72
       repository: armory/deck-armory
-      tag: 2021.09.09.19.58.41.release-2.26.x
+      tag: 2021.09.23.01.01.09.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: b31998c9e3132417354fd8500c7faf55339268b2
+      sha: 7eef9c77d51c23e2442961d0ee5cd351b2ed7024
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:25fe36a2947dd2e46334d6c0fb29841305ef4292f830f547c47dddf0d4f97e72",
        "repository": "armory/deck-armory",
        "tag": "2021.09.23.01.01.09.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "7eef9c77d51c23e2442961d0ee5cd351b2ed7024"
      }
    },
    "name": "deck-armory"
  }
}
```