### PR TITLE
chore(cd): update kayenta-armory version to 2021.09.24.21.10.41.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:0d6339a5bc2dc0d2609564f6c6af1d67c5f42c1527505bf47ce9e2f74a058b13
+      imageId: sha256:990b49b5034498701fc14c09ab2652f44dd7b75069a4ad7188cfb0af6f083441
       repository: armory/kayenta-armory
-      tag: 2021.08.24.00.40.05.release-2.26.x
+      tag: 2021.09.24.21.10.41.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 4f668d1297a5d205d516667c1af6902d0d9f380f
+      sha: 7092324e47c9e0e79e361fa09bfaeecd17e3a9df
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:990b49b5034498701fc14c09ab2652f44dd7b75069a4ad7188cfb0af6f083441",
        "repository": "armory/kayenta-armory",
        "tag": "2021.09.24.21.10.41.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "7092324e47c9e0e79e361fa09bfaeecd17e3a9df"
      }
    },
    "name": "kayenta-armory"
  }
}
```