### PR TITLE
chore(cd): update kayenta-armory version to 2021.09.24.22.28.23.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:3fe4a35a7628a451ef8cd7c64f7f9ed4d69a417e99c8751b1b5d66c835104c49
+      imageId: sha256:7571d73f5a9ad2cff1e7b2083bf862a06342f2f9ea13048765916be8def83a4b
       repository: armory/kayenta-armory
-      tag: 2021.08.25.23.39.20.release-2.27.x
+      tag: 2021.09.24.22.28.23.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: bee81afb5aa461c344c4a01f277d73fe25cef7dc
+      sha: 20e287e64c98b4dcd19acd9e6fbb00e28cc49561
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "7b52ba1da3e168c9aa7a53968e9dd20d04f7ecec"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:7571d73f5a9ad2cff1e7b2083bf862a06342f2f9ea13048765916be8def83a4b",
        "repository": "armory/kayenta-armory",
        "tag": "2021.09.24.22.28.23.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "20e287e64c98b4dcd19acd9e6fbb00e28cc49561"
      }
    },
    "name": "kayenta-armory"
  }
}
```