### PR TITLE
chore(cd): update deck-armory version to 2021.09.27.18.12.21.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:d90060a1d00caf85a4d84d84ff5c708a1263b87e759a826dc3896d843b79f265
+      imageId: sha256:55d4ecb18107b2c9e066807856917dd8d0eaad10bf24b3260519fbabdfc3c904
       repository: armory/deck-armory
-      tag: 2021.09.22.22.48.52.release-2.27.x
+      tag: 2021.09.27.18.12.21.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 7484c28b7e5c5261dcdf04a1efd040873db2df06
+      sha: f947653933b955008a554518e755b2e6f259234c
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9938e1bd4bfaef0ee547284804cdc6a821e7995b"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:55d4ecb18107b2c9e066807856917dd8d0eaad10bf24b3260519fbabdfc3c904",
        "repository": "armory/deck-armory",
        "tag": "2021.09.27.18.12.21.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f947653933b955008a554518e755b2e6f259234c"
      }
    },
    "name": "deck-armory"
  }
}
```