### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.27.20.51.27.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:23c78324d2de56ed588bef371051ef60048309ba8f6bd4eede32b34191345e04
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.27.20.51.27.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: f0a403db5f657329bad7a945d4efa4fbf638693c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "66c835a660242f77bab4f4dd607ed40aec0e3402"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:23c78324d2de56ed588bef371051ef60048309ba8f6bd4eede32b34191345e04",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.27.20.51.27.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f0a403db5f657329bad7a945d4efa4fbf638693c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```