### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.27.23.47.08.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:aa182180080f6bf808f8cde98591d9d672c8898c56c2e7b495ac2e47278c4b41
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.27.23.47.08.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: f6ea93abc1c2269d5d3baee95b1b4639cbab7799
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "814054c5acc1abff0d436d7cdcffa1680ffcb18a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:aa182180080f6bf808f8cde98591d9d672c8898c56c2e7b495ac2e47278c4b41",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.27.23.47.08.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f6ea93abc1c2269d5d3baee95b1b4639cbab7799"
      }
    },
    "name": "clouddriver-armory"
  }
}
```