### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.28.01.14.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:1da1cd678fef11d26aa66292168116f9278ff2af65ad279494dd46408ce082b3
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.28.01.14.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: a87462dff7965858cf2f0f270b1cc181fc6e7512
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "7b8cf3b1618ac850e750b25eae3675cc35b10e1a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1da1cd678fef11d26aa66292168116f9278ff2af65ad279494dd46408ce082b3",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.28.01.14.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a87462dff7965858cf2f0f270b1cc181fc6e7512"
      }
    },
    "name": "clouddriver-armory"
  }
}
```