### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.28.01.31.46.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:f381d5d8e4e329c096e07c124be7fdf3336b7a24e526d37c908fdffc4c6bfd9f
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.28.01.31.46.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: e2b7e1268c2c4fb4d8c5251be1b609f7854645c0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ccd89423ae0c951e6b915812aa4936a829ff0c96"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:f381d5d8e4e329c096e07c124be7fdf3336b7a24e526d37c908fdffc4c6bfd9f",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.28.01.31.46.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e2b7e1268c2c4fb4d8c5251be1b609f7854645c0"
      }
    },
    "name": "clouddriver-armory"
  }
}
```