### PR TITLE
chore(cd): update deck-armory version to 2021.09.28.18.24.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:0f327a0ebee9d35e41287e94a13d094d88407a115cf062b7aece3e43c7a879fd
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.09.28.18.24.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 824b9cdeba754337659028faa3c939b1d7a9d4ce
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "847905b44c44fba72009c2f31b288cd0760e5f4b"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:0f327a0ebee9d35e41287e94a13d094d88407a115cf062b7aece3e43c7a879fd",
        "repository": "armory/deck-armory",
        "tag": "2021.09.28.18.24.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "824b9cdeba754337659028faa3c939b1d7a9d4ce"
      }
    },
    "name": "deck-armory"
  }
}
```