### PR TITLE
chore(cd): update front50-armory version to 2021.09.28.19.00.41.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:017d40cb5ed0a2aa5432c29a1039a974f9cd14b4c0c0c6650fb0ce6381cce9ce
+      imageId: sha256:42a9d4cf46a9949f6e6ed712f201f02152d2c21c6b580a15dbc72c64d6b6ee4e
       repository: armory/front50-armory
-      tag: 2021.08.24.19.28.32.release-2.27.x
+      tag: 2021.09.28.19.00.41.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: bcafedc1fa3ddbb2d4dcbab909f0c1c9800b0715
+      sha: f8d581afb4c37768174b8cb536bbd2fec28a091e
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "1e15b2486cc3e200687ea111e80b540b31e56410"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:42a9d4cf46a9949f6e6ed712f201f02152d2c21c6b580a15dbc72c64d6b6ee4e",
        "repository": "armory/front50-armory",
        "tag": "2021.09.28.19.00.41.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "f8d581afb4c37768174b8cb536bbd2fec28a091e"
      }
    },
    "name": "front50-armory"
  }
}
```