### PR TITLE
chore(cd): update front50-armory version to 2021.09.29.20.21.15.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:f96cec359742371b466f476145995e6c01da5772c3e3c4b9a61809b54042ddc2
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.09.29.20.21.15.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: c767b67c76ed57ff715815a1f061ab8bd3df9643
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "66dc951eb355cbd7183d2af9a872309d83de56d2"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:f96cec359742371b466f476145995e6c01da5772c3e3c4b9a61809b54042ddc2",
        "repository": "armory/front50-armory",
        "tag": "2021.09.29.20.21.15.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "c767b67c76ed57ff715815a1f061ab8bd3df9643"
      }
    },
    "name": "front50-armory"
  }
}
```