### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.30.00.17.01.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:53c83990d94926f0e23a074c485cfc58812e8fce0fdf3f02b8c35b637082b4ef
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.30.00.17.01.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 96332367736403e1f184417c5e683189c4db3e3c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a205aa7f34e8788eda72933fdaf46d4757bd7660"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:53c83990d94926f0e23a074c485cfc58812e8fce0fdf3f02b8c35b637082b4ef",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.30.00.17.01.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "96332367736403e1f184417c5e683189c4db3e3c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```