### PR TITLE
chore(cd): update clouddriver-armory version to 2021.09.30.17.14.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:fa4c9c926277256682ac3de9813d9b72d8ea86aa5d4019a3d7ff11d929613d02
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.09.30.17.14.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 94542357ce503c2bbeb2a2d777e5c00cec6c33cf
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "dce4688f0a64f47b7bcfa0bed2f70475d798136a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:fa4c9c926277256682ac3de9813d9b72d8ea86aa5d4019a3d7ff11d929613d02",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.09.30.17.14.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "94542357ce503c2bbeb2a2d777e5c00cec6c33cf"
      }
    },
    "name": "clouddriver-armory"
  }
}
```