### PR TITLE
chore(cd): update fiat-armory version to 2021.10.01.21.01.46.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:5af68599d66021042b45df8b2c6339e26736d4749767b0911619d5aa3f6dd79a
+      imageId: sha256:809923d030fd9ee20733001ee54c5226f17a0cecaaae95448726d217e49da403
       repository: armory/fiat-armory
-      tag: 2021.08.04.22.53.02.master
+      tag: 2021.10.01.21.01.46.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b51256d70c00653497f0b2f215fcd3721b1a1cdb
+      sha: 9aa020dc674e0d2900c2fe231d79fa3d546877e2
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "09668629f2cf7504955f762f99eb5098fd42b70d"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:809923d030fd9ee20733001ee54c5226f17a0cecaaae95448726d217e49da403",
        "repository": "armory/fiat-armory",
        "tag": "2021.10.01.21.01.46.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "9aa020dc674e0d2900c2fe231d79fa3d546877e2"
      }
    },
    "name": "fiat-armory"
  }
}
```