### PR TITLE
chore(cd): update fiat-armory version to 2021.10.01.21.19.02.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:50997da1a0fa2649f84e1f9ba5688eef41fa6ee467cda94c54dfbb8f62b43e46
+      imageId: sha256:eb0bfe83fac18ed88fa99973db57d833f325959c3ad6f75ee49973a16dd22568
       repository: armory/fiat-armory
-      tag: 2021.09.09.20.07.19.release-2.26.x
+      tag: 2021.10.01.21.19.02.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: ea4874e41748992d24e0a36a5534bc37d0aa0d31
+      sha: db5a1bd90f8b1c87d0c0c6eede360a5f50c7ae47
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:eb0bfe83fac18ed88fa99973db57d833f325959c3ad6f75ee49973a16dd22568",
        "repository": "armory/fiat-armory",
        "tag": "2021.10.01.21.19.02.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "db5a1bd90f8b1c87d0c0c6eede360a5f50c7ae47"
      }
    },
    "name": "fiat-armory"
  }
}
```