### PR TITLE
chore(cd): update kayenta-armory version to 2021.10.01.23.13.04.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:5e25846ae11eac966f0a2381513288b8e316095ad5ebe55713e0aa3c48edae86
+      imageId: sha256:4fabd59cf91bcb4b4e283184524bf251bb43b6d6bbf350369bc11e02dd145d4d
       repository: armory/kayenta-armory
-      tag: 2021.08.04.20.48.44.master
+      tag: 2021.10.01.23.13.04.master
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: c107287f820e68e8692511243a9c02e5a8569279
+      sha: 2db38c70c660e5214a82e6ab90533b8b69812854
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "7b52ba1da3e168c9aa7a53968e9dd20d04f7ecec"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:4fabd59cf91bcb4b4e283184524bf251bb43b6d6bbf350369bc11e02dd145d4d",
        "repository": "armory/kayenta-armory",
        "tag": "2021.10.01.23.13.04.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "2db38c70c660e5214a82e6ab90533b8b69812854"
      }
    },
    "name": "kayenta-armory"
  }
}
```