### PR TITLE
chore(cd): update orca-armory version to 2021.10.01.23.39.04.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:3eae297430bdb351e5aff31c74e52361675740accfe4aafd8245017e0367deb2
+      imageId: sha256:ff73b951dc036e504d4ec9a14fabc5802673e6cc488ac9760fa178d07566debd
       repository: armory/orca-armory
-      tag: 2021.09.09.19.59.10.release-2.26.x
+      tag: 2021.10.01.23.39.04.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: a3463f61ff082502c1c6cb35ea7b01aeee5456a9
+      sha: 624af61e6bf75bc92e67a6bef6439f8ae29ec79a
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "99d6402e0b2744cd309e9bd31d9488aab68e198d"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:ff73b951dc036e504d4ec9a14fabc5802673e6cc488ac9760fa178d07566debd",
        "repository": "armory/orca-armory",
        "tag": "2021.10.01.23.39.04.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "624af61e6bf75bc92e67a6bef6439f8ae29ec79a"
      }
    },
    "name": "orca-armory"
  }
}
```