### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.05.16.51.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:a047e7aa6031c356dee601b004ff9860d5ec7a7d6d27520af7f19eec1d280135
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.10.05.16.51.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 67c0c9abcbcbd59784789be00173d508c5782ed5
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ce7a850c5b33291e0bc52de7c8bde00bf23bd8e2"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a047e7aa6031c356dee601b004ff9860d5ec7a7d6d27520af7f19eec1d280135",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.05.16.51.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "67c0c9abcbcbd59784789be00173d508c5782ed5"
      }
    },
    "name": "clouddriver-armory"
  }
}
```