### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.11.18.36.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:5d3be420f96ebc4dc98b0c4deff96845d885dcef43c6b0b1356e7d343f420ae7
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.10.11.18.36.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: c86c8716b4f9586ee6695a3e5cb6a524ebe6d5bd
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a055ea08c997580be7dfd8c403c660f583eb7f3f"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:5d3be420f96ebc4dc98b0c4deff96845d885dcef43c6b0b1356e7d343f420ae7",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.11.18.36.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "c86c8716b4f9586ee6695a3e5cb6a524ebe6d5bd"
      }
    },
    "name": "clouddriver-armory"
  }
}
```