### PR TITLE
chore(cd): update deck-armory version to 2021.10.11.20.55.17.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:a339053cb6924b14d78eaa801bc32b8c5c657e711d33a9491a465d867cb6f63a
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.10.11.20.55.17.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 3382925af328904fcb826f057cfda97831b89de8
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "4a6dd5c8876babc28570a8cda281dd57ee886292"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a339053cb6924b14d78eaa801bc32b8c5c657e711d33a9491a465d867cb6f63a",
        "repository": "armory/deck-armory",
        "tag": "2021.10.11.20.55.17.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "3382925af328904fcb826f057cfda97831b89de8"
      }
    },
    "name": "deck-armory"
  }
}
```