### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.11.21.17.18.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:4fb28a3adc609e49f85d0b583eecb4b9b024a57a4615542456b3b460ce37ded3
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.10.11.21.17.18.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 2240634f3a1c35935557a627fb23643b611bc2ef
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d12b5f056c508c6bf510ff632a00cf8836d14240"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:4fb28a3adc609e49f85d0b583eecb4b9b024a57a4615542456b3b460ce37ded3",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.11.21.17.18.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "2240634f3a1c35935557a627fb23643b611bc2ef"
      }
    },
    "name": "clouddriver-armory"
  }
}
```