### PR TITLE
chore(cd): update deck-armory version to 2021.10.11.21.14.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:cd041c4df0532c681df5e533039f10dbefc010d5538c4ca0694824795c4a2307
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.10.11.21.14.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: ca4da9609d38690aaaaf9b716f15a2065b6443b9
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "4a6dd5c8876babc28570a8cda281dd57ee886292"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:cd041c4df0532c681df5e533039f10dbefc010d5538c4ca0694824795c4a2307",
        "repository": "armory/deck-armory",
        "tag": "2021.10.11.21.14.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "ca4da9609d38690aaaaf9b716f15a2065b6443b9"
      }
    },
    "name": "deck-armory"
  }
}
```