### PR TITLE
chore(cd): update deck-armory version to 2021.10.12.00.54.49.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:cbbe62ede755875c8ecc1c4dc62b5839018bd091a44aaa05c70bb5c75f888c4e
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.10.12.00.54.49.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: 6b8aaa33be2b1c382932633895351a562d18c5d6
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "91ab3d52be4dd9b05125c3949129de09a2cbdb9e"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:cbbe62ede755875c8ecc1c4dc62b5839018bd091a44aaa05c70bb5c75f888c4e",
        "repository": "armory/deck-armory",
        "tag": "2021.10.12.00.54.49.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "6b8aaa33be2b1c382932633895351a562d18c5d6"
      }
    },
    "name": "deck-armory"
  }
}
```