### PR TITLE
chore(cd): update deck-armory version to 2021.10.12.04.34.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:bc07d298f9f8d4514986a7c121981110536ac8e93603ba034a2d53260051bbc1
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.10.12.04.34.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: f0e6d8169b51c358d3f2e4cfd180fe887fc899dc
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "c1ac25a5aba6ffbebe822a4e13f291013092833d"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:bc07d298f9f8d4514986a7c121981110536ac8e93603ba034a2d53260051bbc1",
        "repository": "armory/deck-armory",
        "tag": "2021.10.12.04.34.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f0e6d8169b51c358d3f2e4cfd180fe887fc899dc"
      }
    },
    "name": "deck-armory"
  }
}
```