### PR TITLE
chore(cd): update deck-armory version to 2021.10.12.17.46.19.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12077472e8c2895f0e363ccc8622db2721d33d16e768107f436aec7df4716b9a
+      imageId: sha256:c165881490cc641a702371a08541a9cc5322b4e17ec873e1040b3526b340d480
       repository: armory/deck-armory
-      tag: 2021.08.04.18.04.30.master
+      tag: 2021.10.12.17.46.19.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: dc9023cee561f5a3ba23bb5b23687ad422daf56b
+      sha: b5c1ac2b68289e6dc20373ab3f47b555e4de5cd7
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "3ca2d551c511bd47709670e140af696d57cde0b0"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:c165881490cc641a702371a08541a9cc5322b4e17ec873e1040b3526b340d480",
        "repository": "armory/deck-armory",
        "tag": "2021.10.12.17.46.19.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "b5c1ac2b68289e6dc20373ab3f47b555e4de5cd7"
      }
    },
    "name": "deck-armory"
  }
}
```