### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.18.20.01.11.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:677a4b7362d6efcd0c6f5dfdc7a6fb60231d3c0e6ac3cf19cd0f5e0869cc19b0
+      imageId: sha256:c78b3452381155b3447d12fb62c88fa3a78c36a47a68b5ac3f044a7bff488ed1
       repository: armory/clouddriver-armory
-      tag: 2021.08.04.23.08.40.master
+      tag: 2021.10.18.20.01.11.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b1569b8d43da28e329a928aa379d3da3d2662769
+      sha: 92a95d521387a93e613e44d0852ed2e448d2992e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "5aa8b51466510714d86375c3a83551848ae9fe5e"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c78b3452381155b3447d12fb62c88fa3a78c36a47a68b5ac3f044a7bff488ed1",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.18.20.01.11.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "92a95d521387a93e613e44d0852ed2e448d2992e"
      }
    },
    "name": "clouddriver-armory"
  }
}
```