### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.18.22.12.11.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:a75f6f0183de6285f966faf15b8239ab6be59b7b41d8377b7b1b5f08751cdc5b
+      imageId: sha256:44020939784aa10be69f03bdfd2fdd56f33283289b8d87ae7a7f085f9f5f9eba
       repository: armory/clouddriver-armory
-      tag: 2021.10.13.00.15.26.release-2.27.x
+      tag: 2021.10.18.22.12.11.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: f8dddc09221407879db167edbce250dc70876d67
+      sha: 572c8cd768d8a8e728b835b866cd8e3849b4ca5b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "eb09c7bbabb895b11ac8a4d4abdb4f0aa8e0a83e"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:44020939784aa10be69f03bdfd2fdd56f33283289b8d87ae7a7f085f9f5f9eba",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.18.22.12.11.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "572c8cd768d8a8e728b835b866cd8e3849b4ca5b"
      }
    },
    "name": "clouddriver-armory"
  }
}
```