### PR TITLE
chore(cd): update orca-armory version to 2021.10.19.17.59.50.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:e4153f47daf9ed8fc20acc45ba43564cc1e014c4b3a415b7641c5a281c185da0
+      imageId: sha256:0c2191aabd54a12ff9c8455f2744e5612073965e026dea22f3cfca76c37272ae
       repository: armory/orca-armory
-      tag: 2021.08.04.23.02.03.master
+      tag: 2021.10.19.17.59.50.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: cfe7f10c6a19d4fd63464db69b12ff7cc2d2e210
+      sha: 671bdbe5c6dd0c3528fd95692571ea7b74c18485
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c95880d0c119d205c4aac55c2f1b9ab867b7e261"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:0c2191aabd54a12ff9c8455f2744e5612073965e026dea22f3cfca76c37272ae",
        "repository": "armory/orca-armory",
        "tag": "2021.10.19.17.59.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "671bdbe5c6dd0c3528fd95692571ea7b74c18485"
      }
    },
    "name": "orca-armory"
  }
}
```