### PR TITLE
chore(cd): update gate-armory version to 2021.10.19.18.00.00.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:a758c54fa14eae1ff36a752d1535294879d816b3b17c51ff07878e823f0f3a72
+      imageId: sha256:89a8900e5b36bd4ffe66b82269de7e1f60ca4420b9ffab8a104e735b3c8f12e5
       repository: armory/gate-armory
-      tag: 2021.08.03.21.02.18.master
+      tag: 2021.10.19.18.00.00.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: a7adf5d3e3d4dc7aad9d0b680150fdb36f7a21b3
+      sha: 9b3f036d54176417e1898e560835e1255170af6f
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "bb61efab86e8a04c3ffe99a1394c51998c92f7fd"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:89a8900e5b36bd4ffe66b82269de7e1f60ca4420b9ffab8a104e735b3c8f12e5",
        "repository": "armory/gate-armory",
        "tag": "2021.10.19.18.00.00.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "9b3f036d54176417e1898e560835e1255170af6f"
      }
    },
    "name": "gate-armory"
  }
}
```