### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.22.19.32.17.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:e04042f3692641931249f34b1907ffe5febb58864e63a6459e6aa70c81b82b93
+      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
       repository: armory/clouddriver-armory
-      tag: 2021.10.20.04.51.37.master
+      tag: 2021.10.22.19.32.17.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 31e0ff898450798fc2aa94295b550e23019d9838
+      sha: 78353dff32c55a5f121262736517f5ee84441874
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "12f494827484ba0d6609b47ca8d17f99be0b5bf0"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.22.19.32.17.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "78353dff32c55a5f121262736517f5ee84441874"
      }
    },
    "name": "clouddriver-armory"
  }
}
```