### PR TITLE
chore(cd): update front50-armory version to 2021.10.22.20.37.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:8fbbda6a31b3c1bf92d1a90b15e58ca5be1aad8e21b0da80e2a7514b1e4d4dfa
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.10.22.20.37.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 9ee14031a2a961a12db1207bfdd03e0d44d311c8
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "6dd1bfd6595857a46bbbf37032b47966c53e78b4"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:8fbbda6a31b3c1bf92d1a90b15e58ca5be1aad8e21b0da80e2a7514b1e4d4dfa",
        "repository": "armory/front50-armory",
        "tag": "2021.10.22.20.37.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "9ee14031a2a961a12db1207bfdd03e0d44d311c8"
      }
    },
    "name": "front50-armory"
  }
}
```