### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.22.22.42.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:62497e6e9c90cee83fb00b2d032b979fbca8f0c1e160348f4eba2d1e60ae12fb
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.10.22.22.42.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: a93c1ce0849f461972a36d2219896c7683fe8722
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d40a5faf4deee644e845d6aa23daa30830dd3d21"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:62497e6e9c90cee83fb00b2d032b979fbca8f0c1e160348f4eba2d1e60ae12fb",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.22.22.42.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a93c1ce0849f461972a36d2219896c7683fe8722"
      }
    },
    "name": "clouddriver-armory"
  }
}
```