### PR TITLE
chore(cd): update deck-armory version to 2021.10.23.00.09.00.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:07e23fcbc1f0f600ab4cb4dfab110de2a2e0eb6f18517de848f1acb26f93ccb4
+      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
       repository: armory/deck-armory
-      tag: 2021.10.22.02.04.46.master
+      tag: 2021.10.23.00.09.00.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: d9ad034a41e3b9223b7b277270ea0bd34d2cf73c
+      sha: 42859843cee2abf4b4322a3608e39d04595e905b
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "35be23d3c6112aab148b53e09983f37ed03b3b1e"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9",
        "repository": "armory/deck-armory",
        "tag": "2021.10.23.00.09.00.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "42859843cee2abf4b4322a3608e39d04595e905b"
      }
    },
    "name": "deck-armory"
  }
}
```