### PR TITLE
chore(cd): update clouddriver-armory version to 2021.10.26.00.35.34.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:706bb55617ca42df7d964516e07fae4891744043484957c1233a09519c4338ca
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.10.26.00.35.34.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: ce4799be22a6ed7b864a856375e0936aaa2e4859
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d40a5faf4deee644e845d6aa23daa30830dd3d21"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:706bb55617ca42df7d964516e07fae4891744043484957c1233a09519c4338ca",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.10.26.00.35.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ce4799be22a6ed7b864a856375e0936aaa2e4859"
      }
    },
    "name": "clouddriver-armory"
  }
}
```