### PR TITLE
chore(cd): update front50-armory version to 2021.10.26.01.13.46.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:924c03ef4fa9a7197b4517ec83f5d66c0de0edf190f07507af0092d6f81d0eea
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.10.26.01.13.46.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: fad125aa9575b9df57d8f275582102014b9c0662
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "6dd1bfd6595857a46bbbf37032b47966c53e78b4"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:924c03ef4fa9a7197b4517ec83f5d66c0de0edf190f07507af0092d6f81d0eea",
        "repository": "armory/front50-armory",
        "tag": "2021.10.26.01.13.46.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "fad125aa9575b9df57d8f275582102014b9c0662"
      }
    },
    "name": "front50-armory"
  }
}
```