### PR TITLE
chore(cd): update gate-armory version to 2021.10.26.01.10.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:6b839eee83d85cc3115ad73bd357043bfc670cb46477c9b5731e5c906f0b935a
+      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
       repository: armory/gate-armory
-      tag: 2021.10.26.00.36.31.master
+      tag: 2021.10.26.01.10.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 6efe692ac4486362dfad2c4e94b1aa1e57680ce6
+      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "bb61efab86e8a04c3ffe99a1394c51998c92f7fd"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1",
        "repository": "armory/gate-armory",
        "tag": "2021.10.26.01.10.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "1a182d01ff9e69ca61341dd1247d81f6590fe044"
      }
    },
    "name": "gate-armory"
  }
}
```