### PR TITLE
chore(cd): update deck-armory version to 2021.10.26.20.45.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
+      imageId: sha256:e812139aace0a8c540c92c9f659e577d51c4e987d4aac725a3b75269b22dd4d1
       repository: armory/deck-armory
-      tag: 2021.10.23.00.09.00.master
+      tag: 2021.10.26.20.45.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 42859843cee2abf4b4322a3608e39d04595e905b
+      sha: 1e6720d6b39965d739d78fae1bdbb2375db76851
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "7f6fc7df47fed0ab045e8cfc692e07ae675f2d96"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:e812139aace0a8c540c92c9f659e577d51c4e987d4aac725a3b75269b22dd4d1",
        "repository": "armory/deck-armory",
        "tag": "2021.10.26.20.45.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1e6720d6b39965d739d78fae1bdbb2375db76851"
      }
    },
    "name": "deck-armory"
  }
}
```