### PR TITLE
chore(cd): update rosco-armory version to 2021.10.28.21.25.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:5e54a1e85faf677a914ca5cb366afab9fc93fb53a6c50e7d0092bd7ad8ebcb73
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.10.28.21.25.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: c7976a8de50f8cabe18deb895e3c32ef2eef0b9c
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:5e54a1e85faf677a914ca5cb366afab9fc93fb53a6c50e7d0092bd7ad8ebcb73",
        "repository": "armory/rosco-armory",
        "tag": "2021.10.28.21.25.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "c7976a8de50f8cabe18deb895e3c32ef2eef0b9c"
      }
    },
    "name": "rosco-armory"
  }
}
```