### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.01.17.33.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:59296b8355e475fb8b2341107582d89f45978762f5812a842fa7d87f1f9fe76f
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.01.17.33.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 8bcfd165c8d5978b90b40eda5d7c1e217e4db71c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "3e467ae9a46cdd632c8e100cb078fcabda578f24"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:59296b8355e475fb8b2341107582d89f45978762f5812a842fa7d87f1f9fe76f",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.01.17.33.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8bcfd165c8d5978b90b40eda5d7c1e217e4db71c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```