### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.01.21.42.02.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:6f6d0d6cf14a2e3b917178a35b50a911347ad272ee460c003065be7f09b8720a
+      imageId: sha256:eb93a7072b503b4138dd7fbb51e94ebf1ef43c98cfd9849937d0c18ad7201ec9
       repository: armory/clouddriver-armory
-      tag: 2021.10.26.20.31.38.release-2.27.x
+      tag: 2021.11.01.21.42.02.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 7ebce68b12380aef189fa5fd4e8d2b3f7dada086
+      sha: 624ba422a1fabec93e7a8dfd6d0f9874476d7f1f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f8c822eb33b622cec001499eae94ae78fdc52f5b"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:eb93a7072b503b4138dd7fbb51e94ebf1ef43c98cfd9849937d0c18ad7201ec9",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.01.21.42.02.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "624ba422a1fabec93e7a8dfd6d0f9874476d7f1f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```