### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.02.16.14.36.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:88d5387a5b8123fb29668b133a36e70f5c9d944810941a2bffbafbc38d51cf65
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.02.16.14.36.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 93235e40cabaea659f6728b2479b153502fc38d4
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0fb3e75faa586f213a39c9fd4145f08e519b2e97"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:88d5387a5b8123fb29668b133a36e70f5c9d944810941a2bffbafbc38d51cf65",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.02.16.14.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "93235e40cabaea659f6728b2479b153502fc38d4"
      }
    },
    "name": "clouddriver-armory"
  }
}
```