### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.03.18.37.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:0416236d19bef7bbfdb32e75d6d13caf57c497087439f7b621a4d23a9b7c9b34
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.03.18.37.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 0f42c4ed4048b93d857855c03a21ad78476114e0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a0be18bd55caf33bc15380e749e814bd2fab755b"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0416236d19bef7bbfdb32e75d6d13caf57c497087439f7b621a4d23a9b7c9b34",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.03.18.37.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "0f42c4ed4048b93d857855c03a21ad78476114e0"
      }
    },
    "name": "clouddriver-armory"
  }
}
```