### PR TITLE
chore(cd): update deck-armory version to 2021.11.03.19.57.50.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
+      imageId: sha256:ee9855b2483918f2e4713168f536cfb7952a6e54277ce60c1850004689a10bd0
       repository: armory/deck-armory
-      tag: 2021.10.23.00.09.00.master
+      tag: 2021.11.03.19.57.50.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 42859843cee2abf4b4322a3608e39d04595e905b
+      sha: 7f2c760172faea9c1a790df2733d5bfed9c18795
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "deee318cc857742bc27aed2e40d51d5bb1fce531"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:ee9855b2483918f2e4713168f536cfb7952a6e54277ce60c1850004689a10bd0",
        "repository": "armory/deck-armory",
        "tag": "2021.11.03.19.57.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "7f2c760172faea9c1a790df2733d5bfed9c18795"
      }
    },
    "name": "deck-armory"
  }
}
```