### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.04.00.08.41.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:dfeeff6f4a1254fc0e43b4b53082010d929568d9c7fa06b87f4f6227b8495f12
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.04.00.08.41.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: b7c48b8de8ffaba73de4bb8ddd5482d32aac89c8
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:dfeeff6f4a1254fc0e43b4b53082010d929568d9c7fa06b87f4f6227b8495f12",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.04.00.08.41.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b7c48b8de8ffaba73de4bb8ddd5482d32aac89c8"
      }
    },
    "name": "clouddriver-armory"
  }
}
```