### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.04.23.53.34.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:7868551d25a7f392e5bfbdce9b706c15acedd6bc9bceb40c750ba04e803151e1
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.04.23.53.34.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 24e64654dc584713866faea775a25e8eaa98adc2
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0e1335955eace96dd11bce5968c49fc90812b549"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:7868551d25a7f392e5bfbdce9b706c15acedd6bc9bceb40c750ba04e803151e1",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.04.23.53.34.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "24e64654dc584713866faea775a25e8eaa98adc2"
      }
    },
    "name": "clouddriver-armory"
  }
}
```