### PR TITLE
chore(cd): update dinghy version to 2021.11.05.15.44.00.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -26,15 +26,15 @@ services:
   dinghy:
     baseService: null
     image:
-      imageId: sha256:981030662d93b8b18f61e4db576d5ee961996be5ed7cc1281fbc84314ee76ff5
+      imageId: sha256:a3d442859aa010827463e3a31c1e96799972cec0bf644baf037a95ecb22189c9
       repository: armory/dinghy
-      tag: 2021.09.09.20.08.42.master
+      tag: 2021.11.05.15.44.00.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: dinghy
         type: github
-      sha: 9f3deb2352c26b6355edd085d2e139967338129d
+      sha: 7feba3a7b859b9595758c7c9e09782e651d9f0f8
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:a3d442859aa010827463e3a31c1e96799972cec0bf644baf037a95ecb22189c9",
        "repository": "armory/dinghy",
        "tag": "2021.11.05.15.44.00.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "7feba3a7b859b9595758c7c9e09782e651d9f0f8"
      }
    },
    "name": "dinghy"
  }
}
```