### PR TITLE
chore(cd): update front50-armory version to 2021.11.05.21.08.07.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:54983f3910067f9ae43eedf1d5be06f83d991c3e1dbf9fcd1b184f388526a602
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.11.05.21.08.07.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: aa03c400de98b317ee159b3fe61fea76d945105e
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "71be7284006579220934a49fcb7b2a49f628eda1"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:54983f3910067f9ae43eedf1d5be06f83d991c3e1dbf9fcd1b184f388526a602",
        "repository": "armory/front50-armory",
        "tag": "2021.11.05.21.08.07.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "aa03c400de98b317ee159b3fe61fea76d945105e"
      }
    },
    "name": "front50-armory"
  }
}
```