### PR TITLE
chore(cd): update fiat-armory version to 2021.11.05.21.08.28.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:44d6a69928c60469a2dd8c41bbcbcfedb68b135157261bae8f85a81966fbcd87
+      imageId: sha256:f55a824236fd73395bca6424046b9cb6f1e440284d75c50cd6b0b3f5bb8da64d
       repository: armory/fiat-armory
-      tag: 2021.10.26.01.13.40.master
+      tag: 2021.11.05.21.08.28.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 26c889c1437d15900dab59ab4f2be6ad8768fe13
+      sha: 5d09a230398ae0fa924878f71772109f542bc10a
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "db34511b455d776172d64cfb1b7fe9d9d9ab861b"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:f55a824236fd73395bca6424046b9cb6f1e440284d75c50cd6b0b3f5bb8da64d",
        "repository": "armory/fiat-armory",
        "tag": "2021.11.05.21.08.28.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "5d09a230398ae0fa924878f71772109f542bc10a"
      }
    },
    "name": "fiat-armory"
  }
}
```