### PR TITLE
chore(cd): update gate-armory version to 2021.11.05.21.09.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:f202c7905a91c7d75862152bcb7b10a8a7ff23930d5f183003ffee740142361c
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2021.11.05.21.09.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: b98fa8d86f22edd4becfff46d915590e132e54f4
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "19de719f37a1f72ed94a5176c3a14e3465b94ca7"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:f202c7905a91c7d75862152bcb7b10a8a7ff23930d5f183003ffee740142361c",
        "repository": "armory/gate-armory",
        "tag": "2021.11.05.21.09.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "b98fa8d86f22edd4becfff46d915590e132e54f4"
      }
    },
    "name": "gate-armory"
  }
}
```