### PR TITLE
chore(cd): update rosco-armory version to 2021.11.05.21.20.36.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:92ba5e456b4d2c7f09fb07e32d369f33e751b096ef06f399c4889872f30febc6
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.11.05.21.20.36.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: 1784c57be7d54392a472b187a147edc0d117344d
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:92ba5e456b4d2c7f09fb07e32d369f33e751b096ef06f399c4889872f30febc6",
        "repository": "armory/rosco-armory",
        "tag": "2021.11.05.21.20.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "1784c57be7d54392a472b187a147edc0d117344d"
      }
    },
    "name": "rosco-armory"
  }
}
```