### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.05.21.25.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:2683f2dad68707c29b3b65fcb8bac946b2210d0340f2c14bc2e30350c1a0440a
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.05.21.25.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 745c4db27f42827e294c3f1d47c9d95e9f0e77c7
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8b04a5c896bc04e5e0061b354ed84c922a379a54"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2683f2dad68707c29b3b65fcb8bac946b2210d0340f2c14bc2e30350c1a0440a",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.05.21.25.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "745c4db27f42827e294c3f1d47c9d95e9f0e77c7"
      }
    },
    "name": "clouddriver-armory"
  }
}
```