### PR TITLE
chore(cd): update echo-armory version to 2021.11.05.23.18.00.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:05dcb6cf34f7fb6ad057518676ceb3cb22aeb01d371a54d36d3faac40561f046
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.11.05.23.18.00.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: a9b0aab3e7c1784503bae14c0d3865cfaf606dca
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:05dcb6cf34f7fb6ad057518676ceb3cb22aeb01d371a54d36d3faac40561f046",
        "repository": "armory/echo-armory",
        "tag": "2021.11.05.23.18.00.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "a9b0aab3e7c1784503bae14c0d3865cfaf606dca"
      }
    },
    "name": "echo-armory"
  }
}
```