### PR TITLE
chore(cd): update fiat-armory version to 2021.11.06.00.22.30.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:44d6a69928c60469a2dd8c41bbcbcfedb68b135157261bae8f85a81966fbcd87
+      imageId: sha256:06d46a2be097a7f319a7525ef1fb4faee2b0a91a1cd8564c1da1394dd84979cb
       repository: armory/fiat-armory
-      tag: 2021.10.26.01.13.40.master
+      tag: 2021.11.06.00.22.30.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 26c889c1437d15900dab59ab4f2be6ad8768fe13
+      sha: 77b1590ca346e5065437e0d98170c632358b8ae6
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:06d46a2be097a7f319a7525ef1fb4faee2b0a91a1cd8564c1da1394dd84979cb",
        "repository": "armory/fiat-armory",
        "tag": "2021.11.06.00.22.30.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "77b1590ca346e5065437e0d98170c632358b8ae6"
      }
    },
    "name": "fiat-armory"
  }
}
```