### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.08.16.22.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:5e61fdb78ca9b9756664b535798bc5774b39b7513103c19b4459bbd55a28e9f1
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.08.16.22.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: b6a7240288064f982be970fa8a7dbb2dc45dbf2f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "7c64030b7347c6a32dcbcd24bbcf1142f48a847b"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:5e61fdb78ca9b9756664b535798bc5774b39b7513103c19b4459bbd55a28e9f1",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.08.16.22.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b6a7240288064f982be970fa8a7dbb2dc45dbf2f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```