### PR TITLE
chore(cd): update fiat-armory version to 2021.11.08.23.37.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:44d6a69928c60469a2dd8c41bbcbcfedb68b135157261bae8f85a81966fbcd87
+      imageId: sha256:3f5630ee4a38a598514a3d27a4b5478802c0ad2b8fbea69bc2ef2464d95c6ca0
       repository: armory/fiat-armory
-      tag: 2021.10.26.01.13.40.master
+      tag: 2021.11.08.23.37.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 26c889c1437d15900dab59ab4f2be6ad8768fe13
+      sha: 3b81f1cbcd34169461371f37e2aa0b6c74d9bc2c
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "3d4a971be253fd04069cc339549fc5462137eda9"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:3f5630ee4a38a598514a3d27a4b5478802c0ad2b8fbea69bc2ef2464d95c6ca0",
        "repository": "armory/fiat-armory",
        "tag": "2021.11.08.23.37.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "3b81f1cbcd34169461371f37e2aa0b6c74d9bc2c"
      }
    },
    "name": "fiat-armory"
  }
}
```