### PR TITLE
chore(cd): update gate-armory version to 2021.11.08.23.38.14.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:df27a4894aa9f02062a3db7a22759da2b256153d35c7c8597a554d08de496628
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2021.11.08.23.38.14.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: 61ffa1ebd11c3b5b57dd9588c956ba414ea4f947
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "ec9ece2a514b301130c4cf78c41814ec6c0d3aa3"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:df27a4894aa9f02062a3db7a22759da2b256153d35c7c8597a554d08de496628",
        "repository": "armory/gate-armory",
        "tag": "2021.11.08.23.38.14.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "61ffa1ebd11c3b5b57dd9588c956ba414ea4f947"
      }
    },
    "name": "gate-armory"
  }
}
```