### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.09.00.02.36.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:391619e853c08d5800f890414fec74dfb91b50df01fd8240aa3206a7f4ec1f55
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.09.00.02.36.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 191d6efda31ab0f50218bc8d5bdad5d5623143ae
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ed236a6fe946007a4136f6206b311525ea460e65"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:391619e853c08d5800f890414fec74dfb91b50df01fd8240aa3206a7f4ec1f55",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.09.00.02.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "191d6efda31ab0f50218bc8d5bdad5d5623143ae"
      }
    },
    "name": "clouddriver-armory"
  }
}
```