### PR TITLE
chore(cd): update orca-armory version to 2021.11.09.00.55.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:a964736da4b915ac0d9c7db11f25d8e4dee374dcdd4e746ad144d4d9b096ee4f
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.11.09.00.55.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: eff1ecb66a9e4b505745fe442203ad9d3506675b
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a964736da4b915ac0d9c7db11f25d8e4dee374dcdd4e746ad144d4d9b096ee4f",
        "repository": "armory/orca-armory",
        "tag": "2021.11.09.00.55.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "eff1ecb66a9e4b505745fe442203ad9d3506675b"
      }
    },
    "name": "orca-armory"
  }
}
```