### PR TITLE
chore(cd): update gate-armory version to 2021.11.11.23.13.56.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:effa115377d89f779133eb4c9714eefa1d3113e0d48e499c0c20d8ea52a4dbcf
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2021.11.11.23.13.56.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: b782e75459fd0c9793d2881c3f3ae7042be21506
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "dac527c7cc179b9d6542306cce0a11e196070d56"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:effa115377d89f779133eb4c9714eefa1d3113e0d48e499c0c20d8ea52a4dbcf",
        "repository": "armory/gate-armory",
        "tag": "2021.11.11.23.13.56.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "b782e75459fd0c9793d2881c3f3ae7042be21506"
      }
    },
    "name": "gate-armory"
  }
}
```