### PR TITLE
chore(cd): update front50-armory version to 2021.11.11.23.11.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:0cab535fde08442c5743b54038532fddc7f8efb71ab0054274d25034a468058f
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.11.11.23.11.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 2028bd07bd383dfdd9e1894fd5688cc93fc46272
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "6beb1e85c1a7aac34483dd58acdb653223edcdec"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:0cab535fde08442c5743b54038532fddc7f8efb71ab0054274d25034a468058f",
        "repository": "armory/front50-armory",
        "tag": "2021.11.11.23.11.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "2028bd07bd383dfdd9e1894fd5688cc93fc46272"
      }
    },
    "name": "front50-armory"
  }
}
```