### PR TITLE
chore(cd): update rosco-armory version to 2021.11.11.23.12.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:7c998aa91908f360db6b37faa80c0bffb8c72948896b99b623fa4bb5cddd6438
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.11.11.23.12.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: ffebec8499b73742472851522759911b1b110f75
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:7c998aa91908f360db6b37faa80c0bffb8c72948896b99b623fa4bb5cddd6438",
        "repository": "armory/rosco-armory",
        "tag": "2021.11.11.23.12.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "ffebec8499b73742472851522759911b1b110f75"
      }
    },
    "name": "rosco-armory"
  }
}
```