### PR TITLE
chore(cd): update orca-armory version to 2021.11.12.01.08.52.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:42812542ac47eba6dc9c4dd8b82b3762946771cb852512da3b62cd9a73cdbaa5
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.11.12.01.08.52.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: 24230f6b949fd34c57c5726b9e860930803ea883
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "b9a3378057aa28831006354c5e4422be664bcffb"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:42812542ac47eba6dc9c4dd8b82b3762946771cb852512da3b62cd9a73cdbaa5",
        "repository": "armory/orca-armory",
        "tag": "2021.11.12.01.08.52.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "24230f6b949fd34c57c5726b9e860930803ea883"
      }
    },
    "name": "orca-armory"
  }
}
```