### PR TITLE
chore(cd): update front50-armory version to 2021.11.12.22.11.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:a5f306de2e84d1a5e7b89a6c486b8625b6397856507aaad5e3dc09735920a93e
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.11.12.22.11.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 45b09f3745dd286ae0cf14da7d7f5835d9015067
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "8c9ba72c02ad01ddb3f4ff797568264d8bab1ea1"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:a5f306de2e84d1a5e7b89a6c486b8625b6397856507aaad5e3dc09735920a93e",
        "repository": "armory/front50-armory",
        "tag": "2021.11.12.22.11.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "45b09f3745dd286ae0cf14da7d7f5835d9015067"
      }
    },
    "name": "front50-armory"
  }
}
```