### PR TITLE
chore(cd): update echo-armory version to 2021.11.15.22.58.52.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:76e91148afcc625d7d33823d3751670b42c87eead0b5e29ced5cbf57dbf38dea
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.11.15.22.58.52.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: f83ea549c51cfa6e8e6faf8d0f8eed40ca40e3ae
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "198905212dbdbd0ade1cab8265ebf07f6497e1ea"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:76e91148afcc625d7d33823d3751670b42c87eead0b5e29ced5cbf57dbf38dea",
        "repository": "armory/echo-armory",
        "tag": "2021.11.15.22.58.52.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "f83ea549c51cfa6e8e6faf8d0f8eed40ca40e3ae"
      }
    },
    "name": "echo-armory"
  }
}
```