### PR TITLE
chore(cd): update front50-armory version to 2021.11.15.22.57.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:02827d8322b5f3784b3f9215b476c0b34efeb53388caabf540b2e1ca017c38b7
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.11.15.22.57.58.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 855fd123bfbd88b543516b52019018c3aee592fb
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "2cc46468f0e01a0d76829b5f59181e4892288c73"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:02827d8322b5f3784b3f9215b476c0b34efeb53388caabf540b2e1ca017c38b7",
        "repository": "armory/front50-armory",
        "tag": "2021.11.15.22.57.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "855fd123bfbd88b543516b52019018c3aee592fb"
      }
    },
    "name": "front50-armory"
  }
}
```