### PR TITLE
chore(cd): update rosco-armory version to 2021.11.15.22.59.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:13438993e0c2a406e92ee0cb72a1fb8cb669fbb0f9eab9d505584da9e5e31b43
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.11.15.22.59.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: 42722f804ae6d03de16d8e96199404f9b2a408a0
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:13438993e0c2a406e92ee0cb72a1fb8cb669fbb0f9eab9d505584da9e5e31b43",
        "repository": "armory/rosco-armory",
        "tag": "2021.11.15.22.59.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "42722f804ae6d03de16d8e96199404f9b2a408a0"
      }
    },
    "name": "rosco-armory"
  }
}
```