### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.15.23.23.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:f45ab4a562df067ea8dc013fe5490b1aaf52b3d2e38d79aac3f6f35a15970ac2
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.15.23.23.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 5d79bf5ab20421c1615d1cfddd04271968d17e25
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "e621fb8e677d79766f519bdb899868907488e450"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:f45ab4a562df067ea8dc013fe5490b1aaf52b3d2e38d79aac3f6f35a15970ac2",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.15.23.23.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5d79bf5ab20421c1615d1cfddd04271968d17e25"
      }
    },
    "name": "clouddriver-armory"
  }
}
```