### PR TITLE
chore(cd): update orca-armory version to 2021.11.16.00.03.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:f100d4d8b59e8c0087bd87d0030b03c19a4ca940d90c55eee2ac3685ce760b98
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.11.16.00.03.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: 3463b8915e84e80177fbbb123c1c5a678e980552
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c5716adf229aefaafabc5f9ad05a5191ac688ebd"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:f100d4d8b59e8c0087bd87d0030b03c19a4ca940d90c55eee2ac3685ce760b98",
        "repository": "armory/orca-armory",
        "tag": "2021.11.16.00.03.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "3463b8915e84e80177fbbb123c1c5a678e980552"
      }
    },
    "name": "orca-armory"
  }
}
```