### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.17.17.52.28.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:2ce6ebd94910b36c833c0bc515f7c4c5a58570a17dcdba70c0c958d2f249c47f
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.17.17.52.28.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: d9ad977c978e98e625d1fbfc5daef085afccba0a
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "96755fec0c04b6e361efb6d1c19a7afc3926e302"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2ce6ebd94910b36c833c0bc515f7c4c5a58570a17dcdba70c0c958d2f249c47f",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.17.17.52.28.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d9ad977c978e98e625d1fbfc5daef085afccba0a"
      }
    },
    "name": "clouddriver-armory"
  }
}
```