### PR TITLE
chore(cd): update deck-armory version to 2021.11.18.23.48.52.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
+      imageId: sha256:0b8eb91b3e7a962116b55c3cff0ae0564ac4ac887062078ed5a00f12b95ee1a8
       repository: armory/deck-armory
-      tag: 2021.10.23.00.09.00.master
+      tag: 2021.11.18.23.48.52.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 42859843cee2abf4b4322a3608e39d04595e905b
+      sha: 3be7d16e0ba22113b38a7e8a1862f9769a119d10
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:0b8eb91b3e7a962116b55c3cff0ae0564ac4ac887062078ed5a00f12b95ee1a8",
        "repository": "armory/deck-armory",
        "tag": "2021.11.18.23.48.52.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "3be7d16e0ba22113b38a7e8a1862f9769a119d10"
      }
    },
    "name": "deck-armory"
  }
}
```