### PR TITLE
chore(cd): update clouddriver-armory version to 2021.11.30.18.36.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:c78ec7e785fd2b8adecd2acc9a30ef82e4e67789d73272212d7e34704872b22e
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.11.30.18.36.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: af00444d802acca81b535b78125af7998f68314c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6626b61917b1fac86a295fc613f39942cf1aeb33"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c78ec7e785fd2b8adecd2acc9a30ef82e4e67789d73272212d7e34704872b22e",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.11.30.18.36.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "af00444d802acca81b535b78125af7998f68314c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```