### PR TITLE
chore(cd): update orca-armory version to 2021.11.30.19.07.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:c9b64bff0ba8548287d868876c6daf07fdcdc39e19b43723d79c106332579557
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.11.30.19.07.58.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: 498e8b55e386a8fb5988e78e8689f26b67d09038
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "1412bd8ecf3a9460f0816baa905e73a612f07ca0"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:c9b64bff0ba8548287d868876c6daf07fdcdc39e19b43723d79c106332579557",
        "repository": "armory/orca-armory",
        "tag": "2021.11.30.19.07.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "498e8b55e386a8fb5988e78e8689f26b67d09038"
      }
    },
    "name": "orca-armory"
  }
}
```