### PR TITLE
chore(cd): update rosco-armory version to 2021.11.30.23.24.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:d9f381d324df4bc7052c7c376af68ed69a0b0c6f9c17c90c5ad476760607969d
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.11.30.23.24.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: 1637a2ac93eb622428d010b655869268d81abb8f
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "4bacf38839e389f4e37e88fa77389347ff2c470a"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:d9f381d324df4bc7052c7c376af68ed69a0b0c6f9c17c90c5ad476760607969d",
        "repository": "armory/rosco-armory",
        "tag": "2021.11.30.23.24.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "1637a2ac93eb622428d010b655869268d81abb8f"
      }
    },
    "name": "rosco-armory"
  }
}
```