### PR TITLE
chore(cd): update echo-armory version to 2021.12.01.10.23.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:b5f00c56dbd1634b233d104800d4ae711fd462cc70a19b3c7284e3e9b4b883d1
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.12.01.10.23.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: b100b30e6ac84f76378301a7e028ac918c8722e4
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "7dc77926dac209ea48171329a9e092fcc2a5ab48"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:b5f00c56dbd1634b233d104800d4ae711fd462cc70a19b3c7284e3e9b4b883d1",
        "repository": "armory/echo-armory",
        "tag": "2021.12.01.10.23.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "b100b30e6ac84f76378301a7e028ac918c8722e4"
      }
    },
    "name": "echo-armory"
  }
}
```