### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.01.16.49.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:bd91ae37d34b1a412ff6f15bdbf39cda007dd09b67d302ca579975d4156adac0
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.01.16.49.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 291c2b9cb6d3b1c034ba894e9b06c88e24e685c0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f3f5e29ec06e7cee9102dd4ab52da66980dd9bac"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:bd91ae37d34b1a412ff6f15bdbf39cda007dd09b67d302ca579975d4156adac0",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.01.16.49.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "291c2b9cb6d3b1c034ba894e9b06c88e24e685c0"
      }
    },
    "name": "clouddriver-armory"
  }
}
```