### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.03.10.36.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:896fdd78301de3878929e499568f0437c67968793ccdd2d568cf4ba9dae98f99
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.03.10.36.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: b7f8eabedc112fce9264d61604b4ea97c9919dc1
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "3a14ce51656f7c4f57f91c00e098fb7f08fec641"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:896fdd78301de3878929e499568f0437c67968793ccdd2d568cf4ba9dae98f99",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.03.10.36.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b7f8eabedc112fce9264d61604b4ea97c9919dc1"
      }
    },
    "name": "clouddriver-armory"
  }
}
```