### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.03.16.14.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:0e18d49d0c615594b9a19bf8b612e1e57b46f71969a7a0d7992c82384a52e5d7
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.03.16.14.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 317b8b283c8669052d2f0d92f4b1a4d1aef758c8
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "af2a1fc3c3031865420ae0620f7d0efeaeebc393"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0e18d49d0c615594b9a19bf8b612e1e57b46f71969a7a0d7992c82384a52e5d7",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.03.16.14.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "317b8b283c8669052d2f0d92f4b1a4d1aef758c8"
      }
    },
    "name": "clouddriver-armory"
  }
}
```