### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.03.22.13.27.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:0e0703cfdb0e737d6b286a868740d6bb002379a24e5880f692cf954d918d912f
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.03.22.13.27.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 67bc9a28f39b696f4cc1fa264c998abaa9cabf3c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "3d7e8588bec328166be9dfcc756d6098e3a38db3"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0e0703cfdb0e737d6b286a868740d6bb002379a24e5880f692cf954d918d912f",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.03.22.13.27.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "67bc9a28f39b696f4cc1fa264c998abaa9cabf3c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```