### PR TITLE
chore(cd): update front50-armory version to 2021.12.04.14.19.12.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:998aacf559a14854349b5ed1642e1fe3d14962138618b726b0a33fb0ed3d7aa5
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.12.04.14.19.12.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 68f9ee369b8a7f38a8f205e251c4167552e45965
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "fe5a9d87a92478eac494f1a511d8ac9ff584297b"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:998aacf559a14854349b5ed1642e1fe3d14962138618b726b0a33fb0ed3d7aa5",
        "repository": "armory/front50-armory",
        "tag": "2021.12.04.14.19.12.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "68f9ee369b8a7f38a8f205e251c4167552e45965"
      }
    },
    "name": "front50-armory"
  }
}
```