### PR TITLE
chore(cd): update echo-armory version to 2021.12.04.14.24.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:5978e4d3a7689a7999f861ab3b191ad7f6af01d0627b194f94a83c1941accc21
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.12.04.14.24.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: 816f77d34f42cdcb59e43eab848d815fb6431200
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "1895d36db230403ed9051943cb9a22777fe049bc"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:5978e4d3a7689a7999f861ab3b191ad7f6af01d0627b194f94a83c1941accc21",
        "repository": "armory/echo-armory",
        "tag": "2021.12.04.14.24.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "816f77d34f42cdcb59e43eab848d815fb6431200"
      }
    },
    "name": "echo-armory"
  }
}
```