### PR TITLE
chore(cd): update rosco-armory version to 2021.12.04.14.28.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:3f1973f2c8c370f7c9b88b3e1a5987f9fb6f0a01378d1fa0da68554de2af986a
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.12.04.14.28.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: 27f689231d4d4dc2f749a810f4b732eefab88561
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "09bebd1fe24dc90f0b2f2f396f843aa83e185898"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:3f1973f2c8c370f7c9b88b3e1a5987f9fb6f0a01378d1fa0da68554de2af986a",
        "repository": "armory/rosco-armory",
        "tag": "2021.12.04.14.28.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "27f689231d4d4dc2f749a810f4b732eefab88561"
      }
    },
    "name": "rosco-armory"
  }
}
```