### PR TITLE
chore(cd): update gate-armory version to 2021.12.04.14.35.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:6c8358568332db0446839315d75df57a89565f3e1ac4230a32a77165180019bb
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2021.12.04.14.35.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: 164f8b44524549b3c196097dfda5ecd4d97de0c8
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "b1337dbd51bb38f1f54691ed0aea93343299835b"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:6c8358568332db0446839315d75df57a89565f3e1ac4230a32a77165180019bb",
        "repository": "armory/gate-armory",
        "tag": "2021.12.04.14.35.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "164f8b44524549b3c196097dfda5ecd4d97de0c8"
      }
    },
    "name": "gate-armory"
  }
}
```