### PR TITLE
chore(cd): update orca-armory version to 2021.12.04.15.15.50.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:52d0716ea68a5f94056c7fceb9b45c44c52ff332f6402ee292c01a90730a9918
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.12.04.15.15.50.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: e7b9397147defeab70e1aad2eda02f30507f6def
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "06709b03f09d23980328f7bd11e50d0f2efbb0b2"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:52d0716ea68a5f94056c7fceb9b45c44c52ff332f6402ee292c01a90730a9918",
        "repository": "armory/orca-armory",
        "tag": "2021.12.04.15.15.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "e7b9397147defeab70e1aad2eda02f30507f6def"
      }
    },
    "name": "orca-armory"
  }
}
```