### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.04.17.25.00.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:725d8e908ea24408440556386750e9b5ed71ce4ffa5e99101efe461d00784d3b
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.04.17.25.00.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 6eab06aed504a4cfc0b01736a98c77667dfa5957
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "bdfc4be10e8380134d73b5122233193364828b5c"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:725d8e908ea24408440556386750e9b5ed71ce4ffa5e99101efe461d00784d3b",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.04.17.25.00.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6eab06aed504a4cfc0b01736a98c77667dfa5957"
      }
    },
    "name": "clouddriver-armory"
  }
}
```