### PR TITLE
chore(cd): update echo-armory version to 2021.12.07.02.03.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:f154bab548737b6815fc00190fe117e824faf8377f54cf87d06fbf547857a610
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.12.07.02.03.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: 84cc84ffb10ed55f81e73eb5f774fd369c52c31c
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "5f554dc614dbe75e9a89842c16b735b4d9a17859"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:f154bab548737b6815fc00190fe117e824faf8377f54cf87d06fbf547857a610",
        "repository": "armory/echo-armory",
        "tag": "2021.12.07.02.03.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "84cc84ffb10ed55f81e73eb5f774fd369c52c31c"
      }
    },
    "name": "echo-armory"
  }
}
```