### PR TITLE
chore(cd): update fiat-armory version to 2021.12.07.02.04.22.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:44d6a69928c60469a2dd8c41bbcbcfedb68b135157261bae8f85a81966fbcd87
+      imageId: sha256:d136a4822cc1d1b9f2ad7c615370c4624989e473f419e99a63e70d4131756f20
       repository: armory/fiat-armory
-      tag: 2021.10.26.01.13.40.master
+      tag: 2021.12.07.02.04.22.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 26c889c1437d15900dab59ab4f2be6ad8768fe13
+      sha: 0bf5166f82af0f271b392df0d2a702ee7a6e4ab0
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "5250764ab6f614ed2d8f644e7726aa5f2c319be3"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:d136a4822cc1d1b9f2ad7c615370c4624989e473f419e99a63e70d4131756f20",
        "repository": "armory/fiat-armory",
        "tag": "2021.12.07.02.04.22.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "0bf5166f82af0f271b392df0d2a702ee7a6e4ab0"
      }
    },
    "name": "fiat-armory"
  }
}
```