### PR TITLE
chore(cd): update rosco-armory version to 2021.12.07.02.08.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:d6f0121316517872a8b21475ccd59b038fede0aef0b30f280f21976b8030f8c2
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.12.07.02.08.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: 47b91bcdcb679363217f3c70efc65e26a23447a4
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "d46c221881b17eb9b15e1ca3ad2a1322b31e0d78"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:d6f0121316517872a8b21475ccd59b038fede0aef0b30f280f21976b8030f8c2",
        "repository": "armory/rosco-armory",
        "tag": "2021.12.07.02.08.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "47b91bcdcb679363217f3c70efc65e26a23447a4"
      }
    },
    "name": "rosco-armory"
  }
}
```