### PR TITLE
chore(cd): update front50-armory version to 2021.12.07.02.10.00.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:c57ccf8022f5142b22ea9a987586d0a9b01c1bcffeff6d20ce1c5309670ca3c5
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.12.07.02.10.00.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: d51fd65116d02a59e31fbb0f8f507e25b7c4d51b
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "3878c2f833b7d5942a7774e75023116e490aa1a0"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c57ccf8022f5142b22ea9a987586d0a9b01c1bcffeff6d20ce1c5309670ca3c5",
        "repository": "armory/front50-armory",
        "tag": "2021.12.07.02.10.00.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "d51fd65116d02a59e31fbb0f8f507e25b7c4d51b"
      }
    },
    "name": "front50-armory"
  }
}
```