### PR TITLE
chore(cd): update orca-armory version to 2021.12.07.02.14.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:463de5114054dad110328dce51e9f861ccaa22b645977f4dca89e972be4f4451
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.12.07.02.14.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: ff69932e1f3c64377207e0dc090780364325e1ed
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "1d96a3b12f65fa40989ed6375d9dee5307fca2fe"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:463de5114054dad110328dce51e9f861ccaa22b645977f4dca89e972be4f4451",
        "repository": "armory/orca-armory",
        "tag": "2021.12.07.02.14.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "ff69932e1f3c64377207e0dc090780364325e1ed"
      }
    },
    "name": "orca-armory"
  }
}
```