### PR TITLE
chore(cd): update gate-armory version to 2021.12.07.02.13.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:0420cea14f08f531d494fd0d85ea2b1aa2ce18c7b2fb7883ef0d3aef0d18645f
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2021.12.07.02.13.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: 324aa15ab161f0ccdbd735bcafe65d59286c9ada
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "6d8ae57bf832d859e8f48e1cf280cba849e68c05"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:0420cea14f08f531d494fd0d85ea2b1aa2ce18c7b2fb7883ef0d3aef0d18645f",
        "repository": "armory/gate-armory",
        "tag": "2021.12.07.02.13.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "324aa15ab161f0ccdbd735bcafe65d59286c9ada"
      }
    },
    "name": "gate-armory"
  }
}
```