### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.07.02.28.42.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:388001fe08d0a83964cf34a7484cad3a8c7e716d565ead2f99b3ff1855ebf642
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.07.02.28.42.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 900acd65beb04a33175d5e52653ad14d48e98fad
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8736e4078198ca4fff4b7533cee0f51407960c3b"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:388001fe08d0a83964cf34a7484cad3a8c7e716d565ead2f99b3ff1855ebf642",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.07.02.28.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "900acd65beb04a33175d5e52653ad14d48e98fad"
      }
    },
    "name": "clouddriver-armory"
  }
}
```