### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.07.22.43.17.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:51b43395d170ac641561ba1fa52a5123f0985d3c7917cd42394b78d56cb30c3a
+      imageId: sha256:04844e02c1e276ca66fa36b9b2b008e45b24c4ae8c0128717e1d9bd746305181
       repository: armory/clouddriver-armory
-      tag: 2021.11.22.16.22.55.release-2.25.x
+      tag: 2021.12.07.22.43.17.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: aedc0c3255961093aa4bb72feaad7fb4a765f9fa
+      sha: 812857e1de9dd5d2f7d846e4d4febee7ec9324d6
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "368c134482bb5e8b5c707386ed55c326e915598b"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:04844e02c1e276ca66fa36b9b2b008e45b24c4ae8c0128717e1d9bd746305181",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.07.22.43.17.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "812857e1de9dd5d2f7d846e4d4febee7ec9324d6"
      }
    },
    "name": "clouddriver-armory"
  }
}
```