### PR TITLE
chore(cd): update orca-armory version to 2021.12.07.23.56.10.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:7cedba175b61fcb151821d942a4990cfb5e969e6e8d06fa3322cd6d26945a3c7
+      imageId: sha256:f4701721a6af6b9750a169c55318d413e2eb848db7694163cd20995d2c0dca0a
       repository: armory/orca-armory
-      tag: 2021.11.08.23.28.26.release-2.25.x
+      tag: 2021.12.07.23.56.10.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 34e86d8b65d7a6510e9b5c499ca5e4e5437d7775
+      sha: 5bd55d9a27f5c57d439bb8d185aaa4e766f96245
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "9bb318af6959c3aef39c203d7752c05996713346"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:f4701721a6af6b9750a169c55318d413e2eb848db7694163cd20995d2c0dca0a",
        "repository": "armory/orca-armory",
        "tag": "2021.12.07.23.56.10.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "5bd55d9a27f5c57d439bb8d185aaa4e766f96245"
      }
    },
    "name": "orca-armory"
  }
}
```