### PR TITLE
chore(cd): update front50-armory version to 2021.12.08.02.20.34.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:e55f0735a34c739b7a2bcb023665d11ba9d880b540044e31efa003070c04b89a
+      imageId: sha256:7e91bbb65586461795a433af699e492bb0ccd5a2219a6876a1aafd9d05fccb74
       repository: armory/front50-armory
-      tag: 2021.11.17.20.39.09.release-2.25.x
+      tag: 2021.12.08.02.20.34.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 76c814f005afecbd1d82a2a86d7362cd8a42f712
+      sha: eac6bc91dcede2bd3faa1d5a43bc3b543231e14a
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "8c8eb50bfb911ddbdcfc2ae2e7d41973933e0544"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:7e91bbb65586461795a433af699e492bb0ccd5a2219a6876a1aafd9d05fccb74",
        "repository": "armory/front50-armory",
        "tag": "2021.12.08.02.20.34.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "eac6bc91dcede2bd3faa1d5a43bc3b543231e14a"
      }
    },
    "name": "front50-armory"
  }
}
```