### PR TITLE
chore(cd): update rosco-armory version to 2021.12.08.02.25.15.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:eb70213af4b462693f5fb4d39941fec3e0d57b92d18c2c0759b15501da1e4f7a
+      imageId: sha256:08b67fd144c56e5bdda426a0b34245dd92766df62963ac32383ce5fe89e7ba78
       repository: armory/rosco-armory
-      tag: 2021.11.09.15.50.18.release-2.25.x
+      tag: 2021.12.08.02.25.15.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: d5e41e75d88dda81a03d7d7a93e79752099fc50f
+      sha: 767ea931f059a5f5d654642d45d8948fd19d3ec5
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "7ef652b01d6619bde7ed00e9c501de7d649af69e"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:08b67fd144c56e5bdda426a0b34245dd92766df62963ac32383ce5fe89e7ba78",
        "repository": "armory/rosco-armory",
        "tag": "2021.12.08.02.25.15.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "767ea931f059a5f5d654642d45d8948fd19d3ec5"
      }
    },
    "name": "rosco-armory"
  }
}
```