### PR TITLE
chore(cd): update orca-armory version to 2021.12.09.13.23.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:7a54a80de6db326bec4d7312d9657f0f14e0e636aa2bbd3832e0c577497bc882
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.12.09.13.23.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: 7e5c1d229493490196fb89b782f487bb121dbcf9
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "0c911497a2ca329a2b86eb15674367dd689376b5"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:7a54a80de6db326bec4d7312d9657f0f14e0e636aa2bbd3832e0c577497bc882",
        "repository": "armory/orca-armory",
        "tag": "2021.12.09.13.23.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "7e5c1d229493490196fb89b782f487bb121dbcf9"
      }
    },
    "name": "orca-armory"
  }
}
```