### PR TITLE
chore(cd): update fiat-armory version to 2021.12.10.19.47.26.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:44d6a69928c60469a2dd8c41bbcbcfedb68b135157261bae8f85a81966fbcd87
+      imageId: sha256:821911723721558b13306adc94fae10122ce2189f75f9fca34fb58a714021ace
       repository: armory/fiat-armory
-      tag: 2021.10.26.01.13.40.master
+      tag: 2021.12.10.19.47.26.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 26c889c1437d15900dab59ab4f2be6ad8768fe13
+      sha: 70fa967d71dc221d0ffc30fddca6518255d95405
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "e3c187385c4d67598d972f4098aabb1c503b1afb"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:821911723721558b13306adc94fae10122ce2189f75f9fca34fb58a714021ace",
        "repository": "armory/fiat-armory",
        "tag": "2021.12.10.19.47.26.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "70fa967d71dc221d0ffc30fddca6518255d95405"
      }
    },
    "name": "fiat-armory"
  }
}
```