### PR TITLE
chore(cd): update rosco-armory version to 2021.12.10.19.51.08.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e3704da3acc4f9d2f34ef623632086c83d4961ccaca9b88c37a7a9c329ce8746
+      imageId: sha256:b7fe72030f533c522d505ad986b983683d9418b47d286fd144324ae7b0718ad2
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.37.18.master
+      tag: 2021.12.10.19.51.08.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 3f16ee2b52559dbfc630365f049bf3b766f0788e
+      sha: 68599d4f089d38c299b848113b31bc6131da6f43
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "6bbb47a8d2a2057d0b3c6f8bc07b296feb9cf35e"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:b7fe72030f533c522d505ad986b983683d9418b47d286fd144324ae7b0718ad2",
        "repository": "armory/rosco-armory",
        "tag": "2021.12.10.19.51.08.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "68599d4f089d38c299b848113b31bc6131da6f43"
      }
    },
    "name": "rosco-armory"
  }
}
```