### PR TITLE
chore(cd): update orca-armory version to 2021.12.11.00.47.20.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:107b234955cb76ca6bf1a92ae449623e8cb3ea3006d2a365da25c956e33a5777
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.12.11.00.47.20.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: 79d5933f94fcbde51f0bc31f9126082003485dae
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "5a68195e98d2bbd7415ccb76f024398309f981fb"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:107b234955cb76ca6bf1a92ae449623e8cb3ea3006d2a365da25c956e33a5777",
        "repository": "armory/orca-armory",
        "tag": "2021.12.11.00.47.20.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "79d5933f94fcbde51f0bc31f9126082003485dae"
      }
    },
    "name": "orca-armory"
  }
}
```