### PR TITLE
chore(cd): update kayenta-armory version to 2021.12.13.15.49.22.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:9920894fbbe814dcd3ccff0dcb17b1c2292f61ab565b1037994ec3d6fc865a66
+      imageId: sha256:bc05722a1e79bc467c6ae7bae373801c56844c61f356d6322a62fa3aa012a04c
       repository: armory/kayenta-armory
-      tag: 2021.11.08.23.28.19.release-2.25.x
+      tag: 2021.12.13.15.49.22.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: ecfccf92c44010b999f3d3f04b9a07e8ed878f8c
+      sha: 8b3cfad9d1b721e29be502d6813ae8658789c098
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "f089465776be82f3f865925d75f5ec71ba478ab2"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:bc05722a1e79bc467c6ae7bae373801c56844c61f356d6322a62fa3aa012a04c",
        "repository": "armory/kayenta-armory",
        "tag": "2021.12.13.15.49.22.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "8b3cfad9d1b721e29be502d6813ae8658789c098"
      }
    },
    "name": "kayenta-armory"
  }
}
```