### PR TITLE
chore(cd): update fiat-armory version to 2021.12.13.18.21.38.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:1c5bc56a8f5ad7cb8778e6bdc0f749083c4a537b516d0a1764dcc9ef3b7a6578
+      imageId: sha256:99b7094196aa14253a2b516701950a7295b5385f3a667742109d1b5b109a4fdc
       repository: armory/fiat-armory
-      tag: 2021.12.08.02.10.24.release-2.25.x
+      tag: 2021.12.13.18.21.38.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c27410e9174f4597be3e670f17d008c1a5f3b3f6
+      sha: fe60b6210c6ce00167aa42143a4dffebcf03fb9f
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "a748d82463dc6671100bca80bd79d4ab43d98102"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:99b7094196aa14253a2b516701950a7295b5385f3a667742109d1b5b109a4fdc",
        "repository": "armory/fiat-armory",
        "tag": "2021.12.13.18.21.38.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "fe60b6210c6ce00167aa42143a4dffebcf03fb9f"
      }
    },
    "name": "fiat-armory"
  }
}
```