### PR TITLE
chore(cd): update igor-armory version to 2021.12.13.18.22.40.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:4588682a3aed929b166ac644155ad1eb5b3a1614b266742e325956b070ee3857
+      imageId: sha256:385991d26039bc303469403dfbceb564494a0605921b6f5e887e610485db150e
       repository: armory/igor-armory
-      tag: 2021.12.08.02.15.54.release-2.25.x
+      tag: 2021.12.13.18.22.40.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 738b4f83957006c54bd4af0a1d68fb4197e74df0
+      sha: 670df68838b5183faa5ab42db3559b20bbfb29c9
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "6cdf2948cd7c0ec649da9e7dbfa90a0183660d21"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:385991d26039bc303469403dfbceb564494a0605921b6f5e887e610485db150e",
        "repository": "armory/igor-armory",
        "tag": "2021.12.13.18.22.40.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "670df68838b5183faa5ab42db3559b20bbfb29c9"
      }
    },
    "name": "igor-armory"
  }
}
```