### PR TITLE
chore(cd): update kayenta-armory version to 2021.12.13.18.28.44.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:bc05722a1e79bc467c6ae7bae373801c56844c61f356d6322a62fa3aa012a04c
+      imageId: sha256:a96b124169d4e97f8ba115f3c3b8cfbb2bde9b9b1b675ae6e5fdf6fdcffa5eb2
       repository: armory/kayenta-armory
-      tag: 2021.12.13.15.49.22.release-2.25.x
+      tag: 2021.12.13.18.28.44.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 8b3cfad9d1b721e29be502d6813ae8658789c098
+      sha: f859543dc93fe2438cca2b7907fde957dde9f64c
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "f089465776be82f3f865925d75f5ec71ba478ab2"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:a96b124169d4e97f8ba115f3c3b8cfbb2bde9b9b1b675ae6e5fdf6fdcffa5eb2",
        "repository": "armory/kayenta-armory",
        "tag": "2021.12.13.18.28.44.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "f859543dc93fe2438cca2b7907fde957dde9f64c"
      }
    },
    "name": "kayenta-armory"
  }
}
```