### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.14.18.37.02.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:2006ea6f1ca13b056692ce3693b6770cdb8521e61eeaaaab4e134e1b74901e61
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.14.18.37.02.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: a9f26022a6e9ec4ca84c28624fc02103a28a4eac
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8b3dcdeb20779f9e3bc3b556649e18915fa75594"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2006ea6f1ca13b056692ce3693b6770cdb8521e61eeaaaab4e134e1b74901e61",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.14.18.37.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a9f26022a6e9ec4ca84c28624fc02103a28a4eac"
      }
    },
    "name": "clouddriver-armory"
  }
}
```