### PR TITLE
chore(cd): update echo-armory version to 2021.12.14.18.10.22.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:1aaf8622229656995dcb842adbd3b085688a323fc11630e7dcfbb476ab469b8f
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.12.14.18.10.22.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: b4907f0840a2ee86bdd166fd8504c06c35622539
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "7d03d4670e14265464993e0f652ef4ce60259178"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:1aaf8622229656995dcb842adbd3b085688a323fc11630e7dcfbb476ab469b8f",
        "repository": "armory/echo-armory",
        "tag": "2021.12.14.18.10.22.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "b4907f0840a2ee86bdd166fd8504c06c35622539"
      }
    },
    "name": "echo-armory"
  }
}
```