### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.14.22.43.43.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:a0a464c7c923d0c3fb6b19f3a4e2ee8b2ed1500301b38e34bb3a4b41b9309ca1
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.14.22.43.43.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: e93a615f6d926ba1e76d36a59069a31b8dc885ae
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "02f3d32cb1943ce20ccd90e9a058bd890b3c34d6"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a0a464c7c923d0c3fb6b19f3a4e2ee8b2ed1500301b38e34bb3a4b41b9309ca1",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.14.22.43.43.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e93a615f6d926ba1e76d36a59069a31b8dc885ae"
      }
    },
    "name": "clouddriver-armory"
  }
}
```