### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.14.22.53.02.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:1e88f908cea6ac6e386a474577b6a67d7ef6e29a5801bdd324cc52a2c50693b5
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2021.12.14.22.53.02.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: b45092c68bc05831fa711baa273998d3f8cf93d0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a2626919ab23feb5a3504375a361eddde8254753"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1e88f908cea6ac6e386a474577b6a67d7ef6e29a5801bdd324cc52a2c50693b5",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.14.22.53.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b45092c68bc05831fa711baa273998d3f8cf93d0"
      }
    },
    "name": "clouddriver-armory"
  }
}
```