### PR TITLE
chore(cd): update echo-armory version to 2021.12.14.22.39.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:e692ebf4d2642b215a9b10081c762179912a8f1c72ecfa038a98123566720433
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2021.12.14.22.39.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: 9285a9d7436391eafd2369333d079d023dad8822
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "c6b71479fb6d0eff202749481fa97f64b128894c"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:e692ebf4d2642b215a9b10081c762179912a8f1c72ecfa038a98123566720433",
        "repository": "armory/echo-armory",
        "tag": "2021.12.14.22.39.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "9285a9d7436391eafd2369333d079d023dad8822"
      }
    },
    "name": "echo-armory"
  }
}
```