### PR TITLE
chore(cd): update igor-armory version to 2021.12.14.22.40.07.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:0ef5c5c987e12d5dee19df19a648edda0f5006793ffa878dd802eeebbb4d395b
+      imageId: sha256:4037854eecda40bc6d439aaba39e997c229555c7b0d2108061f41bcab0e31750
       repository: armory/igor-armory
-      tag: 2021.09.28.19.42.36.master
+      tag: 2021.12.14.22.40.07.master
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: ebf9c12a56a4872f07a5b46077ff8ab45c109c02
+      sha: ed895b479ffed50d6b57c60273b51ae25abf0903
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "cb7684eaa070372648cac4572cb2409634ca6e90"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:4037854eecda40bc6d439aaba39e997c229555c7b0d2108061f41bcab0e31750",
        "repository": "armory/igor-armory",
        "tag": "2021.12.14.22.40.07.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "ed895b479ffed50d6b57c60273b51ae25abf0903"
      }
    },
    "name": "igor-armory"
  }
}
```