### PR TITLE
chore(cd): update deck-armory version to 2021.12.13.23.33.31.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
+      imageId: sha256:933af6be31d7fd331d76147e9a9a7d36c85da59f2878489e86aa502e500119a9
       repository: armory/deck-armory
-      tag: 2021.10.23.00.09.00.master
+      tag: 2021.12.13.23.33.31.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 42859843cee2abf4b4322a3608e39d04595e905b
+      sha: e4cfa8ec5daafc77493ed3931fa1ca5f6232c929
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "187272ef1933753688fb8f7966e250a27104612a"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:933af6be31d7fd331d76147e9a9a7d36c85da59f2878489e86aa502e500119a9",
        "repository": "armory/deck-armory",
        "tag": "2021.12.13.23.33.31.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e4cfa8ec5daafc77493ed3931fa1ca5f6232c929"
      }
    },
    "name": "deck-armory"
  }
}
```