### PR TITLE
chore(cd): update gate-armory version to 2021.12.15.01.35.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:1dec2e2a431552f86a06aae80f896944c7bc6e128efa318ad6ab5f7dfc26f304
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2021.12.15.01.35.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: 8c64eeb40b4e0f0e0451208d2bd5f7785681ca75
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "ab5f22635e6a7466f25a6b8eb6dcdeb41079cc85"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:1dec2e2a431552f86a06aae80f896944c7bc6e128efa318ad6ab5f7dfc26f304",
        "repository": "armory/gate-armory",
        "tag": "2021.12.15.01.35.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "8c64eeb40b4e0f0e0451208d2bd5f7785681ca75"
      }
    },
    "name": "gate-armory"
  }
}
```