### PR TITLE
chore(cd): update front50-armory version to 2021.12.15.01.34.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:6cb0f70dbeacadca475b720ff9cee3cbeecaf588f22078afc42c35b2670d710e
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2021.12.15.01.34.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 653222c0f8f13afa1289095f70a9f3c37429a8ff
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "3505dbf1fae0461c339c0b6e5a55126b9722618b"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:6cb0f70dbeacadca475b720ff9cee3cbeecaf588f22078afc42c35b2670d710e",
        "repository": "armory/front50-armory",
        "tag": "2021.12.15.01.34.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "653222c0f8f13afa1289095f70a9f3c37429a8ff"
      }
    },
    "name": "front50-armory"
  }
}
```