### PR TITLE
chore(cd): update igor-armory version to 2021.12.15.01.34.46.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:0ef5c5c987e12d5dee19df19a648edda0f5006793ffa878dd802eeebbb4d395b
+      imageId: sha256:604c5ed18740ad21bda94dd7a6c739a93597ae883a679981b12e8f8948d75b72
       repository: armory/igor-armory
-      tag: 2021.09.28.19.42.36.master
+      tag: 2021.12.15.01.34.46.master
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: ebf9c12a56a4872f07a5b46077ff8ab45c109c02
+      sha: 7c9f5164affd04d41716164865ea468e2b5b69e3
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "89c8b50b21331dc7893c43f2e4036800929db150"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:604c5ed18740ad21bda94dd7a6c739a93597ae883a679981b12e8f8948d75b72",
        "repository": "armory/igor-armory",
        "tag": "2021.12.15.01.34.46.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "7c9f5164affd04d41716164865ea468e2b5b69e3"
      }
    },
    "name": "igor-armory"
  }
}
```