### PR TITLE
chore(cd): update gate-armory version to 2021.12.15.04.02.54.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:a93c993ab7dbfaa08b65ba5df9ad8d1fcdc4eb76a592c861978259fd8293f538
+      imageId: sha256:9adcfca68f56206e1aab538431078e460c78786cff93bff246aee26954761e18
       repository: armory/gate-armory
-      tag: 2021.10.01.22.56.26.release-2.26.x
+      tag: 2021.12.15.04.02.54.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 99a43759cb8d635d8bd391d9988d47711c6c6f2e
+      sha: da3f91a01bb1f3f0e0b2b165615547f05e1bd0d5
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:9adcfca68f56206e1aab538431078e460c78786cff93bff246aee26954761e18",
        "repository": "armory/gate-armory",
        "tag": "2021.12.15.04.02.54.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "da3f91a01bb1f3f0e0b2b165615547f05e1bd0d5"
      }
    },
    "name": "gate-armory"
  }
}
```