### PR TITLE
chore(cd): update deck-armory version to 2021.12.15.23.53.19.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
+      imageId: sha256:3d3c0c454c5d33955a9436c89a31a808ca86f5cdb4cac618e02bcd36af543c9e
       repository: armory/deck-armory
-      tag: 2021.10.23.00.09.00.master
+      tag: 2021.12.15.23.53.19.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 42859843cee2abf4b4322a3608e39d04595e905b
+      sha: a85b1e9347cf6106d4473481e2ca4212adea7d34
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "187272ef1933753688fb8f7966e250a27104612a"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3d3c0c454c5d33955a9436c89a31a808ca86f5cdb4cac618e02bcd36af543c9e",
        "repository": "armory/deck-armory",
        "tag": "2021.12.15.23.53.19.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "a85b1e9347cf6106d4473481e2ca4212adea7d34"
      }
    },
    "name": "deck-armory"
  }
}
```