### PR TITLE
chore(cd): update deck-armory version to 2021.12.16.05.43.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:40d6969471fb8bf62f671ca746956fafbcbba500f25e44bef4d96e1277e615a9
+      imageId: sha256:ca9839d86a4aca8d1692988a9eb6826a392e74eadac8c2bd0b0f50540f756681
       repository: armory/deck-armory
-      tag: 2021.10.23.00.09.00.master
+      tag: 2021.12.16.05.43.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 42859843cee2abf4b4322a3608e39d04595e905b
+      sha: 94a332e178b39f456625429b0ddbd6988fee553d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "187272ef1933753688fb8f7966e250a27104612a"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:ca9839d86a4aca8d1692988a9eb6826a392e74eadac8c2bd0b0f50540f756681",
        "repository": "armory/deck-armory",
        "tag": "2021.12.16.05.43.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "94a332e178b39f456625429b0ddbd6988fee553d"
      }
    },
    "name": "deck-armory"
  }
}
```