### PR TITLE
chore(cd): update orca-armory version to 2021.12.15.01.34.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:1ef2e8d25a9c11da95516936d5e61bf493901f2b9707a77e752a96a349646548
+      imageId: sha256:8b960b36717a2d358a61e456fb3cc97040556a11784c058b96f08b5db87605d7
       repository: armory/orca-armory
-      tag: 2021.10.26.01.13.58.master
+      tag: 2021.12.15.01.34.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 6c179121901b1648f42f96bd70cda38c2a831150
+      sha: 6eb7885a7210d1d32de5b5b2624a0c89e9d60173
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "63828e2f83eb06ca0151bdc9d5aa2c34f5a3e4c8"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:8b960b36717a2d358a61e456fb3cc97040556a11784c058b96f08b5db87605d7",
        "repository": "armory/orca-armory",
        "tag": "2021.12.15.01.34.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "6eb7885a7210d1d32de5b5b2624a0c89e9d60173"
      }
    },
    "name": "orca-armory"
  }
}
```