### PR TITLE
chore(cd): update deck-armory version to 2021.12.20.16.42.05.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:143946ec5f3fc64140b8ce16d2a70949e9e6dc466d5e1c721625226d17fc06d6
+      imageId: sha256:827a6b0bc0253dd50b130a7273431e12e1f95ec54f42fedc092e72cc3f0cc07b
       repository: armory/deck-armory
-      tag: 2021.09.23.01.58.49.release-2.26.x
+      tag: 2021.12.20.16.42.05.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 198d62eae2710dceed1f462e50a183abba613fef
+      sha: 0180fcf0a08b0121c5d9af9d3c589487368ad7f4
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:827a6b0bc0253dd50b130a7273431e12e1f95ec54f42fedc092e72cc3f0cc07b",
        "repository": "armory/deck-armory",
        "tag": "2021.12.20.16.42.05.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "0180fcf0a08b0121c5d9af9d3c589487368ad7f4"
      }
    },
    "name": "deck-armory"
  }
}
```