### PR TITLE
chore(cd): update fiat-armory version to 2021.12.17.22.26.27.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:44d6a69928c60469a2dd8c41bbcbcfedb68b135157261bae8f85a81966fbcd87
+      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
       repository: armory/fiat-armory
-      tag: 2021.10.26.01.13.40.master
+      tag: 2021.12.17.22.26.27.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 26c889c1437d15900dab59ab4f2be6ad8768fe13
+      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "e1a51803c77bcd438bb56fe7dce178959ab75a04"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c",
        "repository": "armory/fiat-armory",
        "tag": "2021.12.17.22.26.27.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "c74737d58ec81f6a70e7d307d0ba62b28fb93833"
      }
    },
    "name": "fiat-armory"
  }
}
```