### PR TITLE
chore(cd): update clouddriver-armory version to 2021.12.21.16.32.33.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:eb1a6b9bdf1b817e9fabedcb6b59186fd15e9d52284e1281c1d17353b4cfda59
+      imageId: sha256:a1d01d202b52a9cf063233eacedb266d8d1676332fbde41701a0dd5be525296a
       repository: armory/clouddriver-armory
-      tag: 2021.11.03.21.04.44.release-2.27.x
+      tag: 2021.12.21.16.32.33.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: a9bd461d8e5e862925b4c04f77774da97e2ecd73
+      sha: 4f91ef9797deba2491433268299c0e867b37ebca
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0887714e839e487d6d58ab2c9f4c873b842e26f4"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a1d01d202b52a9cf063233eacedb266d8d1676332fbde41701a0dd5be525296a",
        "repository": "armory/clouddriver-armory",
        "tag": "2021.12.21.16.32.33.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "4f91ef9797deba2491433268299c0e867b37ebca"
      }
    },
    "name": "clouddriver-armory"
  }
}
```