### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.04.16.39.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:e84d79843da361e90cf227ffaff5e9ac346a85de803d80158fefd7ef153bca15
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2022.01.04.16.39.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: ca63bb024072bf0a2e3b5c63fbaf437b57ad7da5
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "37f2b29fc01e96cea52872a797b00c6ca8355f28"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:e84d79843da361e90cf227ffaff5e9ac346a85de803d80158fefd7ef153bca15",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.04.16.39.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ca63bb024072bf0a2e3b5c63fbaf437b57ad7da5"
      }
    },
    "name": "clouddriver-armory"
  }
}
```