### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.04.18.42.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:fff494c91d21eaea77ca9bfb6c7da5075ced46dc06a402529b29bf961e1315f2
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2022.01.04.18.42.58.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: 27ec72a7f4b3d4c83e767daac8a2fea82e1e97b9
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "fbb1327edd37ca9d67813eb501a21752827f8c19"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:fff494c91d21eaea77ca9bfb6c7da5075ced46dc06a402529b29bf961e1315f2",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.04.18.42.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "27ec72a7f4b3d4c83e767daac8a2fea82e1e97b9"
      }
    },
    "name": "clouddriver-armory"
  }
}
```