### PR TITLE
chore(cd): update orca-armory version to 2022.01.10.23.05.08.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:b1ccb3629b870033e48b7669a46e0186e6b4e954ba5b33f87652bcfbb2e2c087
+      imageId: sha256:be994bbe8f5bd167f15a23ec285b19922e7970f20b2afd2a8538ec403e9f0298
       repository: armory/orca-armory
-      tag: 2021.12.13.18.20.30.release-2.25.x
+      tag: 2022.01.10.23.05.08.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 8f84752ec39945409533737c25beb2a853fa22d0
+      sha: b249b8966e73ad59495dd4b514913cebddf6d935
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "9bb318af6959c3aef39c203d7752c05996713346"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:be994bbe8f5bd167f15a23ec285b19922e7970f20b2afd2a8538ec403e9f0298",
        "repository": "armory/orca-armory",
        "tag": "2022.01.10.23.05.08.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "b249b8966e73ad59495dd4b514913cebddf6d935"
      }
    },
    "name": "orca-armory"
  }
}
```