### PR TITLE
chore(cd): update echo-armory version to 2022.01.05.00.44.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:4602aa5c1ee3e72dcd1c8be4cb8526f265dc73676a35322b8d94d51daa6b77b7
+      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
       repository: armory/echo-armory
-      tag: 2021.10.26.01.12.55.master
+      tag: 2022.01.05.00.44.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: e1cb549765d97428cd7db863bb12e6a32a5b0c61
+      sha: 76d6578d79fcd5a3776334b005977d7419d55313
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "703d62029a322a6bd9cc8b32bf05561454d4269b"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4",
        "repository": "armory/echo-armory",
        "tag": "2022.01.05.00.44.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "76d6578d79fcd5a3776334b005977d7419d55313"
      }
    },
    "name": "echo-armory"
  }
}
```