### PR TITLE
chore(cd): update terraformer version to 2021.12.08.16.32.05.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:9cc921c8379c9cbd126880b20da7dae62a95579f256652202434e3f4c8edf866
+      imageId: sha256:f29497485b0b75cfd22b3658499189dd6076793a06cf65b5b5207c3f8dbfe443
       repository: armory/terraformer
-      tag: 2021.09.24.16.00.51.master
+      tag: 2021.12.08.16.32.05.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: db152dc3998ad2c9bfc3734ddc3fcfdb66705702
+      sha: a9eacb43c1edd0cb2159ec038eecf246d6147f25


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:f29497485b0b75cfd22b3658499189dd6076793a06cf65b5b5207c3f8dbfe443",
        "repository": "armory/terraformer",
        "tag": "2021.12.08.16.32.05.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "a9eacb43c1edd0cb2159ec038eecf246d6147f25"
      }
    },
    "name": "terraformer"
  }
}
```