### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.07.23.40.35.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:defab362739adb91b5ef370688c49997b9b4e0112609b0c7a8105917627a4082
+      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
       repository: armory/clouddriver-armory
-      tag: 2021.10.22.19.32.17.master
+      tag: 2022.01.07.23.40.35.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 78353dff32c55a5f121262736517f5ee84441874
+      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "264af19f4ae8923f26587b7aadfe44ce051f651d"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.07.23.40.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a"
      }
    },
    "name": "clouddriver-armory"
  }
}
```