### PR TITLE
chore(cd): update front50-armory version to 2022.01.03.21.15.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:1d4df0aa4826401c7c27b16b3c1ffcb4751bc94bfba4305660b95ef540ebc8e3
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2022.01.03.21.15.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: df7bd7029ca6cb45cc28b19759200ed1c7c4ec98
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "3505dbf1fae0461c339c0b6e5a55126b9722618b"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:1d4df0aa4826401c7c27b16b3c1ffcb4751bc94bfba4305660b95ef540ebc8e3",
        "repository": "armory/front50-armory",
        "tag": "2022.01.03.21.15.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "df7bd7029ca6cb45cc28b19759200ed1c7c4ec98"
      }
    },
    "name": "front50-armory"
  }
}
```