### PR TITLE
chore(cd): update gate-armory version to 2022.01.07.23.38.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:913a921c87039a3940d6e191d1b82c34165ecf31058cc0151d21e8e93cc5ccf1
+      imageId: sha256:b6183104b167320db8e96976113d5493ebcfaa66e8d4f3e8a6fd4129ff5d9f87
       repository: armory/gate-armory
-      tag: 2021.10.26.01.10.44.master
+      tag: 2022.01.07.23.38.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 1a182d01ff9e69ca61341dd1247d81f6590fe044
+      sha: ca28e6f04e07a5522f07d80c97a3f170218c0688
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "11d7ce622f7b2463ee0e5222807581e2e0dc4eb1"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:b6183104b167320db8e96976113d5493ebcfaa66e8d4f3e8a6fd4129ff5d9f87",
        "repository": "armory/gate-armory",
        "tag": "2022.01.07.23.38.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "ca28e6f04e07a5522f07d80c97a3f170218c0688"
      }
    },
    "name": "gate-armory"
  }
}
```