### PR TITLE
chore(cd): update orca-armory version to 2022.01.14.21.57.32.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:911dd2d56baf43484bd28ee84b1efdf14708771d55be383e86c6fbcda7650694
+      imageId: sha256:ebdf397676eecce54436c44acbee867ae3f553cbfa381f93249e358629c496fc
       repository: armory/orca-armory
-      tag: 2021.10.26.20.11.53.release-2.27.x
+      tag: 2022.01.14.21.57.32.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 522655a252c5a1a97f7745fe622ba06bccb99a8c
+      sha: d6725661b213ae66525b80957c9f97dbc541055a
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c8e4176effdaa92ea7bc0cd586d8e4d27f6894cb"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:ebdf397676eecce54436c44acbee867ae3f553cbfa381f93249e358629c496fc",
        "repository": "armory/orca-armory",
        "tag": "2022.01.14.21.57.32.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "d6725661b213ae66525b80957c9f97dbc541055a"
      }
    },
    "name": "orca-armory"
  }
}
```