### PR TITLE
chore(cd): update rosco-armory version to 2022.01.17.19.54.17.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:2bc2ee1709e70fb8d93cfff77ebdd838509d7c5843a8c48e9e7dd288bfca95df
+      imageId: sha256:fe9fa29b27111b28106a7ee019bf90f6b8220ba1f70bafd046788bd75a961c87
       repository: armory/rosco-armory
-      tag: 2021.10.01.23.48.56.release-2.27.x
+      tag: 2022.01.17.19.54.17.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: ac6fe57054e435c6058911c4caa177cba5fa64b3
+      sha: 602bdfa18b93511cbc24fb94c833ab4f4cdb8789
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "e97c6f17aa22220a7548569378081a4b0877d545"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:fe9fa29b27111b28106a7ee019bf90f6b8220ba1f70bafd046788bd75a961c87",
        "repository": "armory/rosco-armory",
        "tag": "2022.01.17.19.54.17.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "602bdfa18b93511cbc24fb94c833ab4f4cdb8789"
      }
    },
    "name": "rosco-armory"
  }
}
```