### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.19.20.52.04.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:80b08139aead161892db23d084d6091da573622bedc419b1c0de8dc93734e45a
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.01.19.20.52.04.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 00ae4de2a2193bfab1bbf995d084c1d0a1110589
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "dfe646e411a560f2d9be892d80dce53c74dc22f9"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:80b08139aead161892db23d084d6091da573622bedc419b1c0de8dc93734e45a",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.19.20.52.04.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "00ae4de2a2193bfab1bbf995d084c1d0a1110589"
      }
    },
    "name": "clouddriver-armory"
  }
}
```