### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.19.21.06.53.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:b3e5ee50ea0ae52fadbb3132b116adca6b8db6de6547ac17e6c8af697a12f37d
+      imageId: sha256:2de1055597f2eaf1e361510fbd8142ea73da99ea19413852eff1d66f2352ac78
       repository: armory/clouddriver-armory
-      tag: 2021.12.30.00.54.58.release-2.26.x
+      tag: 2022.01.19.21.06.53.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 19cbc1b09fdc119ad549d82d258c06030260a7d9
+      sha: 2957f1021447910d60f0f6e9e290988c9b5a11e0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "c4be96787e45cebeafacfa23ad1736c2765b98f5"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2de1055597f2eaf1e361510fbd8142ea73da99ea19413852eff1d66f2352ac78",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.19.21.06.53.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "2957f1021447910d60f0f6e9e290988c9b5a11e0"
      }
    },
    "name": "clouddriver-armory"
  }
}
```