### PR TITLE
chore(cd): update deck-armory version to 2022.01.19.21.37.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:95708451a56619dd4b0c9491eadd68e3b3cedbe803e8864f2394407870d86b3f
+      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
       repository: armory/deck-armory
-      tag: 2022.01.17.13.59.26.master
+      tag: 2022.01.19.21.37.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 3ff5b187a976059886d21e78be2a56b0f24967d4
+      sha: 6698d11a99199187680bef52bfc8655d6e708306
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "02b3696f567dae4904996a539415562bcfb7b8b5"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd",
        "repository": "armory/deck-armory",
        "tag": "2022.01.19.21.37.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "6698d11a99199187680bef52bfc8655d6e708306"
      }
    },
    "name": "deck-armory"
  }
}
```