### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.20.08.03.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:6973e13e638c7898484160ffab2fdd8ea2eea2e4989248dd07f34c925facc408
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.01.20.08.03.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 2888d435b228478ce2243cfb778779294d140aff
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "c2d977b67e4afd1fb96198aa91aa9fca81fd8415"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:6973e13e638c7898484160ffab2fdd8ea2eea2e4989248dd07f34c925facc408",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.20.08.03.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "2888d435b228478ce2243cfb778779294d140aff"
      }
    },
    "name": "clouddriver-armory"
  }
}
```