### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.20.22.08.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:659fba33a9bbfed84f141f34a9142f2f40138bacc6521ddb2b5b64e82cedfb80
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.01.20.22.08.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 383813a8004255c1b4794456fcf5f2f2e8861b26
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6599965feede0db28c52bc18261f828c472b75a8"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:659fba33a9bbfed84f141f34a9142f2f40138bacc6521ddb2b5b64e82cedfb80",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.20.22.08.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "383813a8004255c1b4794456fcf5f2f2e8861b26"
      }
    },
    "name": "clouddriver-armory"
  }
}
```