### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.19.20.54.28.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:7aeb08e81f271223f88301127d04928e12906d9a63c076bec7fe9b83937c8d1a
+      imageId: sha256:00785c61189f14829f3d2333c2a8fef9374cea6f2e5c626488110daee2792b4c
       repository: armory/clouddriver-armory
-      tag: 2022.01.14.22.14.43.release-2.27.x
+      tag: 2022.01.19.20.54.28.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c1ebb1e3a7769c3de43c9b537268ff8c8fbce357
+      sha: a4926ef8ef7d0e9c9bdd0681d9a1d0fcdf943155
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8c1e9ec1a850b61b8d1d58d4c2392e394b94dd9b"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:00785c61189f14829f3d2333c2a8fef9374cea6f2e5c626488110daee2792b4c",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.19.20.54.28.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a4926ef8ef7d0e9c9bdd0681d9a1d0fcdf943155"
      }
    },
    "name": "clouddriver-armory"
  }
}
```