### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.21.22.13.01.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:5217af18e870e8c681834e6ea3a901a79f8c70b50befe13e7a565a036e21ee22
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.01.21.22.13.01.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 8f27e3ca6b1d509244be1a7fd633589065fa7f9a
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d4be9ddfd4d82945fbadce504bf2aa7617fd0524"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:5217af18e870e8c681834e6ea3a901a79f8c70b50befe13e7a565a036e21ee22",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.21.22.13.01.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8f27e3ca6b1d509244be1a7fd633589065fa7f9a"
      }
    },
    "name": "clouddriver-armory"
  }
}
```