### PR TITLE
chore(cd): update echo-armory version to 2022.01.25.21.21.49.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:968fa636b65d9bdeb7ff04b764b93b575ba653b00b7cc642f93e3cae3980de5f
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.01.25.21.21.49.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 1b89707f11af61953f608eff2f965c555632559d
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "703d62029a322a6bd9cc8b32bf05561454d4269b"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:968fa636b65d9bdeb7ff04b764b93b575ba653b00b7cc642f93e3cae3980de5f",
        "repository": "armory/echo-armory",
        "tag": "2022.01.25.21.21.49.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "1b89707f11af61953f608eff2f965c555632559d"
      }
    },
    "name": "echo-armory"
  }
}
```