### PR TITLE
chore(cd): update fiat-armory version to 2022.01.25.21.21.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
+      imageId: sha256:8bf75ec0ed8132613fde8377ffe321326f2badb3f8ca955708f814726c5cf10e
       repository: armory/fiat-armory
-      tag: 2021.12.17.22.26.27.master
+      tag: 2022.01.25.21.21.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
+      sha: 3303b1250d68420d62ded6ec041ec79ff03c678c
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "e1a51803c77bcd438bb56fe7dce178959ab75a04"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:8bf75ec0ed8132613fde8377ffe321326f2badb3f8ca955708f814726c5cf10e",
        "repository": "armory/fiat-armory",
        "tag": "2022.01.25.21.21.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "3303b1250d68420d62ded6ec041ec79ff03c678c"
      }
    },
    "name": "fiat-armory"
  }
}
```