### PR TITLE
chore(cd): update kayenta-armory version to 2022.01.25.21.22.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:25af0ca83ab35f19bdedecf57cc5c1e04e3fe3c84a127e6f28d35303f103785b
+      imageId: sha256:8761b90bd674cadbb90fdb0988830efe9c1b41572340230bcf211035c197c841
       repository: armory/kayenta-armory
-      tag: 2021.12.17.22.22.57.master
+      tag: 2022.01.25.21.22.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 2ee458ac9f2dc90c9fe181bfcd50501195d6a5ac
+      sha: db0c11a416c75b9b5b30e21689dcf1f372229f69
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "8484bc093f44401d2a6bb141820712dbf5b328ee"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:8761b90bd674cadbb90fdb0988830efe9c1b41572340230bcf211035c197c841",
        "repository": "armory/kayenta-armory",
        "tag": "2022.01.25.21.22.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "db0c11a416c75b9b5b30e21689dcf1f372229f69"
      }
    },
    "name": "kayenta-armory"
  }
}
```