### PR TITLE
chore(cd): update fiat-armory version to 2022.01.25.21.34.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
+      imageId: sha256:ac3e748d03475145daaa611a890a52cdd9fb5d2026c024488dd1fdfde80c60f7
       repository: armory/fiat-armory
-      tag: 2021.12.17.22.26.27.master
+      tag: 2022.01.25.21.34.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
+      sha: cefe8cde9777ee96e16da94f61072c19fa6b6ca7
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "b423f22cd86e6f71c228edc34c2f92398f83c6b3"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:ac3e748d03475145daaa611a890a52cdd9fb5d2026c024488dd1fdfde80c60f7",
        "repository": "armory/fiat-armory",
        "tag": "2022.01.25.21.34.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "cefe8cde9777ee96e16da94f61072c19fa6b6ca7"
      }
    },
    "name": "fiat-armory"
  }
}
```