### PR TITLE
chore(cd): update igor-armory version to 2022.01.25.21.52.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:9e9a630edaff47cfae417bdb84d6be931cf27e96925302a057622584f6a14681
+      imageId: sha256:4e8d2c5d22cca7822df5d6c0f977cbc0a1b6d4772e7e82c8b7f6622261e48696
       repository: armory/igor-armory
-      tag: 2021.12.17.22.26.34.master
+      tag: 2022.01.25.21.52.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 016ecb6036301855be1e3a37c979ed1b4f3bd4b4
+      sha: 0878d10a88f25ec0b7d7de5056132190bf07b4dc
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "f9811156635a219f3655906b64ed75c61194235c"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:4e8d2c5d22cca7822df5d6c0f977cbc0a1b6d4772e7e82c8b7f6622261e48696",
        "repository": "armory/igor-armory",
        "tag": "2022.01.25.21.52.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "0878d10a88f25ec0b7d7de5056132190bf07b4dc"
      }
    },
    "name": "igor-armory"
  }
}
```