### PR TITLE
chore(cd): update igor-armory version to 2022.01.25.21.58.22.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:385991d26039bc303469403dfbceb564494a0605921b6f5e887e610485db150e
+      imageId: sha256:220eea3a226945a94ac81ca477c4446316fccf14ef2b3a162ee9545d7da4b2b4
       repository: armory/igor-armory
-      tag: 2021.12.13.18.22.40.release-2.25.x
+      tag: 2022.01.25.21.58.22.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 670df68838b5183faa5ab42db3559b20bbfb29c9
+      sha: 93fa4ca0c23b45b0f6ec815d78ee4b00eb6ea2aa
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "6cdf2948cd7c0ec649da9e7dbfa90a0183660d21"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:220eea3a226945a94ac81ca477c4446316fccf14ef2b3a162ee9545d7da4b2b4",
        "repository": "armory/igor-armory",
        "tag": "2022.01.25.21.58.22.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "93fa4ca0c23b45b0f6ec815d78ee4b00eb6ea2aa"
      }
    },
    "name": "igor-armory"
  }
}
```