### PR TITLE
chore(cd): update fiat-armory version to 2022.01.25.22.01.48.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:3484d347aed74b5b6c7adf0e616981dc75467bbadeeb57f8ec559f4943d82bab
+      imageId: sha256:3f02e48b29fa2ad1dcd4cce498a25ed129c0130a0be9c99bb1d25e08862d619f
       repository: armory/fiat-armory
-      tag: 2022.01.25.21.52.58.release-2.27.x
+      tag: 2022.01.25.22.01.48.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b4c066f3afd4f0f46c9f41c8d9df0e54693d7ab6
+      sha: 542dddde02ca97a29ebefcee2983f87074e03a56
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "9010e21ebd4ed02273172bc65b2f2335d872e0bc"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:3f02e48b29fa2ad1dcd4cce498a25ed129c0130a0be9c99bb1d25e08862d619f",
        "repository": "armory/fiat-armory",
        "tag": "2022.01.25.22.01.48.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "542dddde02ca97a29ebefcee2983f87074e03a56"
      }
    },
    "name": "fiat-armory"
  }
}
```