### PR TITLE
chore(cd): update orca-armory version to 2022.01.25.22.02.49.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:ebdf397676eecce54436c44acbee867ae3f553cbfa381f93249e358629c496fc
+      imageId: sha256:a53d025d0d806952ef1ffe1101d9cbd38a69269bcfeb57ca8fb1a085bd09e4db
       repository: armory/orca-armory
-      tag: 2022.01.14.21.57.32.release-2.27.x
+      tag: 2022.01.25.22.02.49.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: d6725661b213ae66525b80957c9f97dbc541055a
+      sha: 16a92c39278fb6aea5dfb1ba287bf849e93fdcf2
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c8e4176effdaa92ea7bc0cd586d8e4d27f6894cb"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a53d025d0d806952ef1ffe1101d9cbd38a69269bcfeb57ca8fb1a085bd09e4db",
        "repository": "armory/orca-armory",
        "tag": "2022.01.25.22.02.49.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "16a92c39278fb6aea5dfb1ba287bf849e93fdcf2"
      }
    },
    "name": "orca-armory"
  }
}
```