### PR TITLE
chore(cd): update clouddriver-armory version to 2022.01.28.22.03.56.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:fcf0ea4517a674b10d4d6455028679be84bf2983f9168361b31b9ddd90427734
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.01.28.22.03.56.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 6d68b6f2f7b71f3b9e25d4818b79bdd263e53817
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f67c809903dc12914b75646b072539c44b6ddfdb"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:fcf0ea4517a674b10d4d6455028679be84bf2983f9168361b31b9ddd90427734",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.01.28.22.03.56.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6d68b6f2f7b71f3b9e25d4818b79bdd263e53817"
      }
    },
    "name": "clouddriver-armory"
  }
}
```