### PR TITLE
chore(cd): update clouddriver-armory version to 2022.02.01.22.11.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:e1826e9e15975d434f68c4a4a21c6236e077f0b86513058685770e4774458184
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.02.01.22.11.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 6986685f3345d1964f906531007bd6ccde0d4d51
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b960ee9b217d47757f3b0187bf9739a8b3ec18b7"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:e1826e9e15975d434f68c4a4a21c6236e077f0b86513058685770e4774458184",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.02.01.22.11.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6986685f3345d1964f906531007bd6ccde0d4d51"
      }
    },
    "name": "clouddriver-armory"
  }
}
```