### PR TITLE
chore(cd): update front50-armory version to 2022.02.03.09.21.15.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:080fd25d9f99864b3ea784884ff23958bb623feb41de09ddd910f32a32167018
+      imageId: sha256:a02d2ab54b217874d62fb3283719ac81abcb11e21ef8ba1b4d3951685bd24ee0
       repository: armory/front50-armory
-      tag: 2022.01.28.04.26.39.release-2.27.x
+      tag: 2022.02.03.09.21.15.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 458493bd5d93097e56ec1171719c1feda4f00862
+      sha: 029e81691b6efd99d4174abb5e24b287bf9a29da
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "deb0b895d424703487de8b2df52f558caa977f0c"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:a02d2ab54b217874d62fb3283719ac81abcb11e21ef8ba1b4d3951685bd24ee0",
        "repository": "armory/front50-armory",
        "tag": "2022.02.03.09.21.15.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "029e81691b6efd99d4174abb5e24b287bf9a29da"
      }
    },
    "name": "front50-armory"
  }
}
```