### PR TITLE
chore(cd): update gate-armory version to 2022.02.03.09.31.21.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:d644282dc176e4ed35410732ef1d52ec3c233f52439cbb467e418fc9a479f5ca
+      imageId: sha256:4b531e80e18ad05a079b3aff37bd1be8c8e28c01f82eb9dbdf8f097b687e2cbb
       repository: armory/gate-armory
-      tag: 2022.01.28.04.30.52.release-2.25.x
+      tag: 2022.02.03.09.31.21.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 360a00406d4f9eb5812b0f2f0c7c79a04c3cd621
+      sha: f003918a676b28522784a5a26bfb6be0d7caab1a
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "84eb1f47944b6e9eb445439155a7e2227b696855"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:4b531e80e18ad05a079b3aff37bd1be8c8e28c01f82eb9dbdf8f097b687e2cbb",
        "repository": "armory/gate-armory",
        "tag": "2022.02.03.09.31.21.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "f003918a676b28522784a5a26bfb6be0d7caab1a"
      }
    },
    "name": "gate-armory"
  }
}
```