### PR TITLE
chore(cd): update kayenta-armory version to 2022.02.03.22.52.49.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:560cf69466f1ad2c41a9fde7c14e6fdea7358c1cb16903fa04bb1401bbf8d355
+      imageId: sha256:02de3048227ee47eb1bf10f35058713901ef7c586b20033a24b1f6ce94ff94fb
       repository: armory/kayenta-armory
-      tag: 2021.10.01.23.35.47.release-2.27.x
+      tag: 2022.02.03.22.52.49.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 1cdf69a42c359a1f12077b6b1cba5606ac3e5daf
+      sha: 37f2ed19817d8b2403185c2dbae8dbd32071c9da
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "7b52ba1da3e168c9aa7a53968e9dd20d04f7ecec"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:02de3048227ee47eb1bf10f35058713901ef7c586b20033a24b1f6ce94ff94fb",
        "repository": "armory/kayenta-armory",
        "tag": "2022.02.03.22.52.49.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "37f2ed19817d8b2403185c2dbae8dbd32071c9da"
      }
    },
    "name": "kayenta-armory"
  }
}
```