### PR TITLE
chore(cd): update orca-armory version to 2022.02.04.18.43.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:7bb853b001f733ff15a80d7bd4e04ed813e466212081a28d80fff4a14353b35d
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.02.04.18.43.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: e8afe87b92faf37196cee58dcc14d62758d71c63
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "e516cf58a3927264ec5b8a5535a468f6dabd0f76"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:7bb853b001f733ff15a80d7bd4e04ed813e466212081a28d80fff4a14353b35d",
        "repository": "armory/orca-armory",
        "tag": "2022.02.04.18.43.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "e8afe87b92faf37196cee58dcc14d62758d71c63"
      }
    },
    "name": "orca-armory"
  }
}
```