### PR TITLE
chore(cd): update orca-armory version to 2022.02.04.18.59.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:70fbac0830a4f869998d900dcb29840a69e1f8b7a19496217e79af32dabe3205
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.02.04.18.59.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 1d666df2baaa818f89925599e52a377590488492
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "ca38cf26fde6900f821359ce6d1ca89192d8afd9"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:70fbac0830a4f869998d900dcb29840a69e1f8b7a19496217e79af32dabe3205",
        "repository": "armory/orca-armory",
        "tag": "2022.02.04.18.59.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "1d666df2baaa818f89925599e52a377590488492"
      }
    },
    "name": "orca-armory"
  }
}
```