### PR TITLE
chore(cd): update clouddriver-armory version to 2022.02.07.20.42.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:09cae8a71fec9dc24d08b4b6a811683d9f18c683dc9dfccf26847308250af28c
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.02.07.20.42.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 99806bea2d96c96caeae46af523f55c09363a126
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "cb31a6f53666db4698cd6ce6bf784ce1b41c1353"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:09cae8a71fec9dc24d08b4b6a811683d9f18c683dc9dfccf26847308250af28c",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.02.07.20.42.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "99806bea2d96c96caeae46af523f55c09363a126"
      }
    },
    "name": "clouddriver-armory"
  }
}
```