### PR TITLE
chore(cd): update clouddriver-armory version to 2022.02.08.21.04.22.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:921496ae608adb4d32c7b17bce45af44e3024c51de224f56e56e9f88fdb55f4c
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.02.08.21.04.22.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 6c73eeb9de4537ebf914def78faabe4986ce59fa
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f3b393402c603f5b19f7cc10ac88d137269b702c"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:921496ae608adb4d32c7b17bce45af44e3024c51de224f56e56e9f88fdb55f4c",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.02.08.21.04.22.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6c73eeb9de4537ebf914def78faabe4986ce59fa"
      }
    },
    "name": "clouddriver-armory"
  }
}
```