### PR TITLE
chore(cd): update orca-armory version to 2022.02.08.22.28.09.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:f7abd96da0bbbe5153bd18edc3be146274bb579ba8eefecb5dfb2078ae148aaa
+      imageId: sha256:8c69efa6efd89a1be1bf5120f6448801177c7ca2bb14842e8c775fd87aa7e44c
       repository: armory/orca-armory
-      tag: 2022.02.03.22.33.53.release-2.27.x
+      tag: 2022.02.08.22.28.09.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: bf4894e80ca7b4c9d5608a8c1ec5e26aa993f3df
+      sha: 540e5efebce7be47ef154d05af279c79292e6ec0
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "dc204ef3c9be60d2b7ba4b0f5c47ce7f43236536"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:8c69efa6efd89a1be1bf5120f6448801177c7ca2bb14842e8c775fd87aa7e44c",
        "repository": "armory/orca-armory",
        "tag": "2022.02.08.22.28.09.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "540e5efebce7be47ef154d05af279c79292e6ec0"
      }
    },
    "name": "orca-armory"
  }
}
```