### PR TITLE
chore(cd): update front50-armory version to 2022.02.09.18.32.26.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:6cba7c2a4d66bfa86b6fd2220f9bd0a96acf2527869e28ac944578887147f2fe
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2022.02.09.18.32.26.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 225775346c2db4b1453e8ac4c49b279e93a638df
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "e1ab64747f26bcd824a04f1a3a304a3e5f865cbe"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:6cba7c2a4d66bfa86b6fd2220f9bd0a96acf2527869e28ac944578887147f2fe",
        "repository": "armory/front50-armory",
        "tag": "2022.02.09.18.32.26.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "225775346c2db4b1453e8ac4c49b279e93a638df"
      }
    },
    "name": "front50-armory"
  }
}
```