### PR TITLE
chore(cd): update orca-armory version to 2022.02.09.18.40.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:bfcda9ecedd0e358c5c6fc6856cc4abe8fbccc80961e33ba2c7b005df9889950
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.02.09.18.40.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 0d66ac5195a15f64ba420c8196d0b7848c924f25
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "85017d72ae58b081fbd2c3f7b53418e1e2473885"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:bfcda9ecedd0e358c5c6fc6856cc4abe8fbccc80961e33ba2c7b005df9889950",
        "repository": "armory/orca-armory",
        "tag": "2022.02.09.18.40.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "0d66ac5195a15f64ba420c8196d0b7848c924f25"
      }
    },
    "name": "orca-armory"
  }
}
```