### PR TITLE
chore(cd): update echo-armory version to 2022.02.15.05.31.36.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:ed4060e80be568d0b06b595681a8357da1c1843e2a497af14a52376b0f16abf9
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.02.15.05.31.36.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 36b4bb09ce00ae35ffdb8b4acf9fd777312db522
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "46b5234b292eabae9edf455e16195fa87852e6e7"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:ed4060e80be568d0b06b595681a8357da1c1843e2a497af14a52376b0f16abf9",
        "repository": "armory/echo-armory",
        "tag": "2022.02.15.05.31.36.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "36b4bb09ce00ae35ffdb8b4acf9fd777312db522"
      }
    },
    "name": "echo-armory"
  }
}
```