### PR TITLE
chore(cd): update rosco-armory version to 2022.02.18.00.28.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:eed36c0ea6205a9a2c192da4c85aced5344f9e5bc2c4a56a31d0024955074f01
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.02.18.00.28.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 0b4976330fb8ddecae505e82e99fbf25e3e8cc56
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "ce6cf1ba50a63f6516171cdd3775b922c41a49fa"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:eed36c0ea6205a9a2c192da4c85aced5344f9e5bc2c4a56a31d0024955074f01",
        "repository": "armory/rosco-armory",
        "tag": "2022.02.18.00.28.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "0b4976330fb8ddecae505e82e99fbf25e3e8cc56"
      }
    },
    "name": "rosco-armory"
  }
}
```