### PR TITLE
chore(cd): update rosco-armory version to 2022.02.18.00.53.42.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:d74045c0b13ad02d51411d29f459631d44326fbb5820ab6427cd740252580821
+      imageId: sha256:bb674f3739d8690e35936bc764d51a9ad5f9827a84408280411288a430dc3a2c
       repository: armory/rosco-armory
-      tag: 2022.02.18.00.44.03.release-2.27.x
+      tag: 2022.02.18.00.53.42.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 302572b67a6df13c49e442d1eb93ab521144fb44
+      sha: e3a18b73772f25c98bb286017b9e815219ee7db7
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "c37dd8187c3acc6c011ff5e9e99ddc24bec9e6e9"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:bb674f3739d8690e35936bc764d51a9ad5f9827a84408280411288a430dc3a2c",
        "repository": "armory/rosco-armory",
        "tag": "2022.02.18.00.53.42.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "e3a18b73772f25c98bb286017b9e815219ee7db7"
      }
    },
    "name": "rosco-armory"
  }
}
```