### PR TITLE
chore(cd): update clouddriver-armory version to 2022.02.18.15.11.50.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:7aafb53c2056befa8ca252f3f4f686f0e7f2c6c60d2fa815e3a687aa50d9143b
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.02.18.15.11.50.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: e1b569172855de551209ccc1b30662c62636e678
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "bab7544581ffffb46398e4540f75812666d5c112"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:7aafb53c2056befa8ca252f3f4f686f0e7f2c6c60d2fa815e3a687aa50d9143b",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.02.18.15.11.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e1b569172855de551209ccc1b30662c62636e678"
      }
    },
    "name": "clouddriver-armory"
  }
}
```