### PR TITLE
chore(cd): update rosco-armory version to 2022.02.18.15.49.23.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:434669b448682334354d4362aa871672f3c3c6b790fd2340b475ae52cc1b2a5e
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.02.18.15.49.23.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: ac7a6fe82dd09c63c6adf826024773122972fc9e
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "2654f0031e8435fd7674f41a8550cfaec1925349"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:434669b448682334354d4362aa871672f3c3c6b790fd2340b475ae52cc1b2a5e",
        "repository": "armory/rosco-armory",
        "tag": "2022.02.18.15.49.23.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "ac7a6fe82dd09c63c6adf826024773122972fc9e"
      }
    },
    "name": "rosco-armory"
  }
}
```