### PR TITLE
chore(cd): update rosco-armory version to 2022.02.19.00.49.37.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:5f091777e0d4b247ce9820cb4b19ad7a11e0a1669753cac957b7ddfca77736e8
+      imageId: sha256:1cb7532ea4e0aae7b75113465a160fea8c23f657a9ea7ff5a80251e962638b18
       repository: armory/rosco-armory
-      tag: 2022.02.18.17.13.24.release-2.26.x
+      tag: 2022.02.19.00.49.37.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 8062b9248caef3da9f1631d133f9084f000293bb
+      sha: 02d4d0eb9b99a27e2d536cb096173e152f29b986
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:1cb7532ea4e0aae7b75113465a160fea8c23f657a9ea7ff5a80251e962638b18",
        "repository": "armory/rosco-armory",
        "tag": "2022.02.19.00.49.37.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "02d4d0eb9b99a27e2d536cb096173e152f29b986"
      }
    },
    "name": "rosco-armory"
  }
}
```