### PR TITLE
chore(cd): update front50-armory version to 2022.02.22.17.25.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:281b65b4917dd15cf6e30d794b9d72a1ea7672d080fa24cc592df6b913778938
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2022.02.22.17.25.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: dc1e13a542ac3d783d1c0f3817a32f1b95092d8d
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "e8c7adc1db5f1ef87b2c12d65612f85edbbd7a59"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:281b65b4917dd15cf6e30d794b9d72a1ea7672d080fa24cc592df6b913778938",
        "repository": "armory/front50-armory",
        "tag": "2022.02.22.17.25.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "dc1e13a542ac3d783d1c0f3817a32f1b95092d8d"
      }
    },
    "name": "front50-armory"
  }
}
```