### PR TITLE
chore(cd): update gate-armory version to 2022.02.22.17.27.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:b6183104b167320db8e96976113d5493ebcfaa66e8d4f3e8a6fd4129ff5d9f87
+      imageId: sha256:abc7876796258baac7875f3659602709fba45c042a6dbf76886a9ee30bcc3880
       repository: armory/gate-armory
-      tag: 2022.01.07.23.38.30.master
+      tag: 2022.02.22.17.27.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: ca28e6f04e07a5522f07d80c97a3f170218c0688
+      sha: 03a1e6930a4dca86abcb5da7b4d5083b0091c0a8
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "c9eb62ccef896e6c6cdb7f8ff7ce7b1d065904d6"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:abc7876796258baac7875f3659602709fba45c042a6dbf76886a9ee30bcc3880",
        "repository": "armory/gate-armory",
        "tag": "2022.02.22.17.27.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "03a1e6930a4dca86abcb5da7b4d5083b0091c0a8"
      }
    },
    "name": "gate-armory"
  }
}
```