### PR TITLE
chore(cd): update echo-armory version to 2022.02.22.21.55.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:d4f1335708f73ff852012391bb4f6c989dcc6b96cccc6f7a8f7f5c58bf362009
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.02.22.21.55.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: f9fc22c94843c47a1f3a2ede2a9d6560fdc347c1
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "b7001105801b743e86576eb266b157e8857b4bbb"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:d4f1335708f73ff852012391bb4f6c989dcc6b96cccc6f7a8f7f5c58bf362009",
        "repository": "armory/echo-armory",
        "tag": "2022.02.22.21.55.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "f9fc22c94843c47a1f3a2ede2a9d6560fdc347c1"
      }
    },
    "name": "echo-armory"
  }
}
```