### PR TITLE
chore(cd): update clouddriver-armory version to 2022.02.23.20.04.11.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:a910db8ed616c300f562e9f3e86027f831c750f11ece0ac5c184331b8fd31a02
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.02.23.20.04.11.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: daa55be5fb980040ef7c3e7fe5d273b07411e52e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6731924e80ee241ffd0022f531da71b2b2df4950"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a910db8ed616c300f562e9f3e86027f831c750f11ece0ac5c184331b8fd31a02",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.02.23.20.04.11.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "daa55be5fb980040ef7c3e7fe5d273b07411e52e"
      }
    },
    "name": "clouddriver-armory"
  }
}
```