### PR TITLE
chore(cd): update clouddriver-armory version to 2022.02.24.21.11.28.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:5b8135173bf736cc7203f88f22c6249496a8a850cad76d1849075992295d77c9
+      imageId: sha256:dfc5ff8401670946ade5b9a9067384d7196eba3d03ef6e1dfcf2a7e37bfaa473
       repository: armory/clouddriver-armory
-      tag: 2022.02.23.23.36.19.release-2.26.x
+      tag: 2022.02.24.21.11.28.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: d0b1d8833b2aa56a009c60da9d86d33e70f14033
+      sha: 2404e31144ad768ea6970085f5280e784cbd39e9
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b809c79086e3eec4752fed77a9d33093ca807c78"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:dfc5ff8401670946ade5b9a9067384d7196eba3d03ef6e1dfcf2a7e37bfaa473",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.02.24.21.11.28.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "2404e31144ad768ea6970085f5280e784cbd39e9"
      }
    },
    "name": "clouddriver-armory"
  }
}
```