### PR TITLE
chore(cd): update orca-armory version to 2022.02.25.22.39.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:fa8f34004eea4fc4aafd33b68140c7a312d11d494e4b28be56d9ccdc04548256
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.02.25.22.39.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 7e6bfaeaca57cccc88a23381ea9c4f598172eb87
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "9586ec7178f5ba04fe1caf2ee7eda90e166ead5d"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:fa8f34004eea4fc4aafd33b68140c7a312d11d494e4b28be56d9ccdc04548256",
        "repository": "armory/orca-armory",
        "tag": "2022.02.25.22.39.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "7e6bfaeaca57cccc88a23381ea9c4f598172eb87"
      }
    },
    "name": "orca-armory"
  }
}
```