### PR TITLE
chore(cd): update orca-armory version to 2022.03.03.05.12.35.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:6502fedab2325e6e1ae6c2f06534535ec14d04c1817d9f3262348b65a73e63f4
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.03.05.12.35.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 2d42b6c82126e96573d416ece443765cf3559e70
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "ede484cd7851cd2d5505c5674af30063c57a19f7"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:6502fedab2325e6e1ae6c2f06534535ec14d04c1817d9f3262348b65a73e63f4",
        "repository": "armory/orca-armory",
        "tag": "2022.03.03.05.12.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "2d42b6c82126e96573d416ece443765cf3559e70"
      }
    },
    "name": "orca-armory"
  }
}
```