### PR TITLE
chore(cd): update fiat-armory version to 2022.03.03.05.13.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
+      imageId: sha256:2e2919c17ed6f88b1ee8c5005eb47f0fbbceaeec45167ffd8287400de2b53a5a
       repository: armory/fiat-armory
-      tag: 2021.12.17.22.26.27.master
+      tag: 2022.03.03.05.13.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
+      sha: 9fba40364c590a025d958d30b46d2854f04f8528
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "a6f4da7e77901421e9a8c04e5dbf6b03f9f1af47"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:2e2919c17ed6f88b1ee8c5005eb47f0fbbceaeec45167ffd8287400de2b53a5a",
        "repository": "armory/fiat-armory",
        "tag": "2022.03.03.05.13.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "9fba40364c590a025d958d30b46d2854f04f8528"
      }
    },
    "name": "fiat-armory"
  }
}
```