### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.03.05.16.20.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:2989480aa3a427c7963f86e68c9ba8b0430ecfef59b8c07d47f26f7711b01fb7
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.03.05.16.20.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: f9989cb4728083cb55e05955594c28ed477ff152
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "734ef176711a4a5d7532d887dc2e40b4a62fed17"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2989480aa3a427c7963f86e68c9ba8b0430ecfef59b8c07d47f26f7711b01fb7",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.03.05.16.20.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f9989cb4728083cb55e05955594c28ed477ff152"
      }
    },
    "name": "clouddriver-armory"
  }
}
```