### PR TITLE
chore(cd): update rosco-armory version to 2022.03.03.05.18.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:5b426e9f29ac35c7b32ffd73ec20eda0a15e72964a467c4b79ebc46553587603
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.03.05.18.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 8b7ce9756fa669e1b456352672bb27d138c2a3e1
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "b01875d1e4684657a72d94021d2d9de4bb902093"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:5b426e9f29ac35c7b32ffd73ec20eda0a15e72964a467c4b79ebc46553587603",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.03.05.18.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "8b7ce9756fa669e1b456352672bb27d138c2a3e1"
      }
    },
    "name": "rosco-armory"
  }
}
```