### PR TITLE
chore(cd): update orca-armory version to 2022.03.04.01.20.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:28390b2b51938839ee35ae151441beae1402bb76a653936c78c04c2b4d886594
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.04.01.20.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: a64c1626b774b6868023d37ed11daf06fd7304bf
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "da0247df2fc9cd4257744517747b8c6b0853a6f8"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:28390b2b51938839ee35ae151441beae1402bb76a653936c78c04c2b4d886594",
        "repository": "armory/orca-armory",
        "tag": "2022.03.04.01.20.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "a64c1626b774b6868023d37ed11daf06fd7304bf"
      }
    },
    "name": "orca-armory"
  }
}
```