### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.04.01.25.33.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:cf260d5b52a352e4fc0ebe8df7052f27fac931d68cc0b31d7379ef39e15e88b6
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.04.01.25.33.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 1b3831e766c2454d7632e5d5ad72e45202d34da3
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "38fda69f0740d02fe73e99284ea60641651b0e57"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:cf260d5b52a352e4fc0ebe8df7052f27fac931d68cc0b31d7379ef39e15e88b6",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.04.01.25.33.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "1b3831e766c2454d7632e5d5ad72e45202d34da3"
      }
    },
    "name": "clouddriver-armory"
  }
}
```