### PR TITLE
chore(cd): update front50-armory version to 2022.03.04.04.42.14.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:8fe6cb8030733e621a19bc9128a47c3813c27e7ef118953ab18d544729a645f6
+      imageId: sha256:51a4e4b3eb28fd5d58d2d97ebdfe07793abe197b2ffc785461ed490e635d916a
       repository: armory/front50-armory
-      tag: 2022.02.22.22.35.08.release-2.27.x
+      tag: 2022.03.04.04.42.14.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: e60edec818a2c0633c9e809b1cca66a03e640d9a
+      sha: cdb90f4dc3d55c2a5150a3e573b1862cef93816b
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "deb0b895d424703487de8b2df52f558caa977f0c"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:51a4e4b3eb28fd5d58d2d97ebdfe07793abe197b2ffc785461ed490e635d916a",
        "repository": "armory/front50-armory",
        "tag": "2022.03.04.04.42.14.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "cdb90f4dc3d55c2a5150a3e573b1862cef93816b"
      }
    },
    "name": "front50-armory"
  }
}
```