### PR TITLE
chore(cd): update echo-armory version to 2022.03.04.16.54.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:b20007d19e5ee1a3144d8f9dd9fbddfcd81986f38472e204f83b57adce4557dd
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.04.16.54.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 5405d7340242e0d13ea960c14bb85f6676711eff
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "f7d4b80afd8d3d3b704348676b1dda66df885cb1"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:b20007d19e5ee1a3144d8f9dd9fbddfcd81986f38472e204f83b57adce4557dd",
        "repository": "armory/echo-armory",
        "tag": "2022.03.04.16.54.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "5405d7340242e0d13ea960c14bb85f6676711eff"
      }
    },
    "name": "echo-armory"
  }
}
```