### PR TITLE
chore(cd): update igor-armory version to 2022.03.04.16.54.26.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:9e9a630edaff47cfae417bdb84d6be931cf27e96925302a057622584f6a14681
+      imageId: sha256:e8ee741631c1e2020f64f1f27bb078c16c14707131e589e33bee945b38a75dca
       repository: armory/igor-armory
-      tag: 2021.12.17.22.26.34.master
+      tag: 2022.03.04.16.54.26.master
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 016ecb6036301855be1e3a37c979ed1b4f3bd4b4
+      sha: ea980119b82c9bcedbbd8eb2f6f900158c55d065
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "b08ada5a0141cdb5fb68dbd727a816cb53cab0ab"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:e8ee741631c1e2020f64f1f27bb078c16c14707131e589e33bee945b38a75dca",
        "repository": "armory/igor-armory",
        "tag": "2022.03.04.16.54.26.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "ea980119b82c9bcedbbd8eb2f6f900158c55d065"
      }
    },
    "name": "igor-armory"
  }
}
```