### PR TITLE
chore(cd): update rosco-armory version to 2022.03.04.16.58.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:7ccfecea5158e2e53e3854abdbaac27ae47c7ff499e4d20cb67c96d14170078c
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.04.16.58.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: b14dc67b6a373185748c5f078723512423570354
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "e7363acb9a1edfd8b8a2aa995f08bb8b79c5a27b"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:7ccfecea5158e2e53e3854abdbaac27ae47c7ff499e4d20cb67c96d14170078c",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.04.16.58.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "b14dc67b6a373185748c5f078723512423570354"
      }
    },
    "name": "rosco-armory"
  }
}
```