### PR TITLE
chore(cd): update deck-armory version to 2022.03.04.17.12.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:a4fe7b35e380e00325d2f9b82140eb7288bb94c19f10cf288287335d11323acd
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.04.17.12.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: c4b14aa213d88a2fcb22c7b74688da8c84638611
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "daad9d485db30c89465b7759d74bdf3e53316eb6"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:a4fe7b35e380e00325d2f9b82140eb7288bb94c19f10cf288287335d11323acd",
        "repository": "armory/deck-armory",
        "tag": "2022.03.04.17.12.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "c4b14aa213d88a2fcb22c7b74688da8c84638611"
      }
    },
    "name": "deck-armory"
  }
}
```