### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.04.17.15.41.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:7145ede73f485fad23f33f6510c197b404a39b22bd5afb3215361f86f97c97c3
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.04.17.15.41.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 60105be4206385d0c1b4d6f11c202d25dbe8c7b2
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "26ffc0b60b7ca131dbce491dea400063630fde0d"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:7145ede73f485fad23f33f6510c197b404a39b22bd5afb3215361f86f97c97c3",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.04.17.15.41.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "60105be4206385d0c1b4d6f11c202d25dbe8c7b2"
      }
    },
    "name": "clouddriver-armory"
  }
}
```