### PR TITLE
chore(cd): update rosco-armory version to 2022.03.04.17.43.45.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:78cf4be29590d55325f3e8debe0099548fc4f0760e12435169455057555d2bff
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.04.17.43.45.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 0435a089dc522de79d13ad997aaa19af6890320a
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "d10c34cce16cca77db1b97f88db9eaba1d8115e4"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:78cf4be29590d55325f3e8debe0099548fc4f0760e12435169455057555d2bff",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.04.17.43.45.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "0435a089dc522de79d13ad997aaa19af6890320a"
      }
    },
    "name": "rosco-armory"
  }
}
```