### PR TITLE
chore(cd): update rosco-armory version to 2022.03.04.18.15.43.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:62a533f537f4f16eb52b9c3340dd81dd7f3ad86ca40aa33677163b27974e86f3
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.04.18.15.43.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: c44a0ea7a1c1d236605742762f7fe5037ee559c1
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "930bbddcc51d42004c0716865bee727651fc1fbc"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:62a533f537f4f16eb52b9c3340dd81dd7f3ad86ca40aa33677163b27974e86f3",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.04.18.15.43.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "c44a0ea7a1c1d236605742762f7fe5037ee559c1"
      }
    },
    "name": "rosco-armory"
  }
}
```