### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.04.18.33.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:db9fea4ce703499da0b1d5b4a0fb5aaf100e52acf5b5add6f3fe3faf9e3f2d3a
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.04.18.33.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 77b7f92642d811713f0f4cb4aa337763a1502b5e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "7e5d5f53c5e738764e98da529ddd6c29d8ebe8d5"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:db9fea4ce703499da0b1d5b4a0fb5aaf100e52acf5b5add6f3fe3faf9e3f2d3a",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.04.18.33.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "77b7f92642d811713f0f4cb4aa337763a1502b5e"
      }
    },
    "name": "clouddriver-armory"
  }
}
```