### PR TITLE
chore(cd): update deck-armory version to 2022.03.04.18.33.04.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:843de2b8945a38c87b30ea10b5a18b74a113d3c9846b20e1c5be7844d3bbb56f
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.04.18.33.04.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: 4575e6b3ee34801f1cedcaea4510000727923fa4
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "17dec9a0ec28ddf2d7114833ce05705c37a9d442"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:843de2b8945a38c87b30ea10b5a18b74a113d3c9846b20e1c5be7844d3bbb56f",
        "repository": "armory/deck-armory",
        "tag": "2022.03.04.18.33.04.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "4575e6b3ee34801f1cedcaea4510000727923fa4"
      }
    },
    "name": "deck-armory"
  }
}
```