### PR TITLE
chore(cd): update igor-armory version to 2022.03.07.16.48.01.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:0ddb80ee7dd2297d683fe34846f07d0a8419722480d79503a2e1df163e56d1b7
+      imageId: sha256:bcf0ab202c432f714d08629efd9670f038c7178c8d845c7c2a028ebe4e0da3c2
       repository: armory/igor-armory
-      tag: 2022.01.25.21.58.17.release-2.26.x
+      tag: 2022.03.07.16.48.01.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: f705bacda745f08fa93629c7412e644a5ba22043
+      sha: cbfed4705d2f57f97061d3a44c9345390b6b11d0
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:bcf0ab202c432f714d08629efd9670f038c7178c8d845c7c2a028ebe4e0da3c2",
        "repository": "armory/igor-armory",
        "tag": "2022.03.07.16.48.01.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "cbfed4705d2f57f97061d3a44c9345390b6b11d0"
      }
    },
    "name": "igor-armory"
  }
}
```