### PR TITLE
chore(cd): update echo-armory version to 2022.03.08.18.14.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:b9064ffbc09598bb7d205d73bdced920c7c0c7b407884bb6a0fa0325fddaf155
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.08.18.14.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 6b5ec2a3571b0fbc0ecbc416c77b84a7f95676ae
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "7d2f534045c7f049ef704ea7736e502c6a577e89"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:b9064ffbc09598bb7d205d73bdced920c7c0c7b407884bb6a0fa0325fddaf155",
        "repository": "armory/echo-armory",
        "tag": "2022.03.08.18.14.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "6b5ec2a3571b0fbc0ecbc416c77b84a7f95676ae"
      }
    },
    "name": "echo-armory"
  }
}
```