### PR TITLE
chore(cd): update orca-armory version to 2022.03.08.18.14.52.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:15041b1725f07ba28b48976a9d8e06323351a6ee7954d048e0f780e8e388f8ae
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.08.18.14.52.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: eade473394bf7cc070aaf8819c95bf2b609848fa
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "1a2645cec9c25ec649751ce4390a341e142296c6"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:15041b1725f07ba28b48976a9d8e06323351a6ee7954d048e0f780e8e388f8ae",
        "repository": "armory/orca-armory",
        "tag": "2022.03.08.18.14.52.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "eade473394bf7cc070aaf8819c95bf2b609848fa"
      }
    },
    "name": "orca-armory"
  }
}
```