### PR TITLE
chore(cd): update rosco-armory version to 2022.03.08.18.14.55.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:cd015cbeb4848e6b8bb060430e5b4c0c5a832c837d8e90e1bf2a6642fd92acae
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.08.18.14.55.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: f1c836af63aa9592f76705a3ffb2acd4d047b678
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "a071a3304f14df81de7244556ec2e999ec031235"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:cd015cbeb4848e6b8bb060430e5b4c0c5a832c837d8e90e1bf2a6642fd92acae",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.08.18.14.55.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "f1c836af63aa9592f76705a3ffb2acd4d047b678"
      }
    },
    "name": "rosco-armory"
  }
}
```