### PR TITLE
chore(cd): update fiat-armory version to 2022.03.08.18.14.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
+      imageId: sha256:58c4b6a4b0e68c39c38c5dc4b4aaa72ee20ee670dce9cc688d1748c492c8a7d3
       repository: armory/fiat-armory
-      tag: 2021.12.17.22.26.27.master
+      tag: 2022.03.08.18.14.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
+      sha: 4423a382642e9fd46cf7c99f9fcaec0556324457
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "9bbea68ca8d972b28802d351dfce93f9e7f19bba"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:58c4b6a4b0e68c39c38c5dc4b4aaa72ee20ee670dce9cc688d1748c492c8a7d3",
        "repository": "armory/fiat-armory",
        "tag": "2022.03.08.18.14.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "4423a382642e9fd46cf7c99f9fcaec0556324457"
      }
    },
    "name": "fiat-armory"
  }
}
```