### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.08.20.03.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:6629253cbf71ee5cbfe615fedd01ae2dafb67db9d307f245763ff307e6b1e343
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.08.20.03.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 1ed5d0a5b25f7168b3f80dcc9fcccd2887ad9914
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a2725257923b6f7eac76cab1a5199cebdb140428"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:6629253cbf71ee5cbfe615fedd01ae2dafb67db9d307f245763ff307e6b1e343",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.08.20.03.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "1ed5d0a5b25f7168b3f80dcc9fcccd2887ad9914"
      }
    },
    "name": "clouddriver-armory"
  }
}
```