### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.08.22.43.12.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:befebfc7c398974bfde12cff8661bc566d82ef2916ba64487b6e4fe53031e238
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.08.22.43.12.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 88c9f4cd2d9a8b19db33cf842d42f8ec34e38722
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "272fb8f8e54a406236bbf7f42cabafe568474f46"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:befebfc7c398974bfde12cff8661bc566d82ef2916ba64487b6e4fe53031e238",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.08.22.43.12.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "88c9f4cd2d9a8b19db33cf842d42f8ec34e38722"
      }
    },
    "name": "clouddriver-armory"
  }
}
```