### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.09.17.12.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:36ff908b0ebd9d3c4a9287866dd2af8bc17c2cb1dc485747bce33b3406c67b8d
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.09.17.12.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 51406b5924b9baf684b8652fdc894de5d4910738
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "272fb8f8e54a406236bbf7f42cabafe568474f46"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:36ff908b0ebd9d3c4a9287866dd2af8bc17c2cb1dc485747bce33b3406c67b8d",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.09.17.12.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "51406b5924b9baf684b8652fdc894de5d4910738"
      }
    },
    "name": "clouddriver-armory"
  }
}
```