### PR TITLE
chore(cd): update rosco-armory version to 2022.03.10.04.46.56.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:ea75193730cd53ab7ba2f886a18aacc5898b2821b0ca9ed4397684304314f24a
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.10.04.46.56.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 61a05b9d84fc51a4b069fcf6edd367d37f06793a
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "5d4375adb8dee178236472087b586c23b66f7beb"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:ea75193730cd53ab7ba2f886a18aacc5898b2821b0ca9ed4397684304314f24a",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.10.04.46.56.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "61a05b9d84fc51a4b069fcf6edd367d37f06793a"
      }
    },
    "name": "rosco-armory"
  }
}
```