### PR TITLE
chore(cd): update rosco-armory version to 2022.03.10.06.02.40.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:5cec0c0ba0459ab4c8a8c03bd36eb7f286f137eecaab27fc52fdc7c72ef44b6c
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.10.06.02.40.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 454be835e5b02b8891acb0ba5de8980517ee54d0
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "63127876b64390b858390e7edb8ba53a2cd2367c"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:5cec0c0ba0459ab4c8a8c03bd36eb7f286f137eecaab27fc52fdc7c72ef44b6c",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.10.06.02.40.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "454be835e5b02b8891acb0ba5de8980517ee54d0"
      }
    },
    "name": "rosco-armory"
  }
}
```