### PR TITLE
chore(cd): update rosco-armory version to 2022.03.10.06.31.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:6ecd2106e7b79a1ab9ae0da34faaf42f2100b61c3d9173f62e482d7d4e538a71
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.10.06.31.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 12c87371642bf7fac3d0725c4a89e9e0207d7b10
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "23ad5df4cbce9895f2f1c54d8daf75ada5863a0a"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:6ecd2106e7b79a1ab9ae0da34faaf42f2100b61c3d9173f62e482d7d4e538a71",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.10.06.31.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "12c87371642bf7fac3d0725c4a89e9e0207d7b10"
      }
    },
    "name": "rosco-armory"
  }
}
```