### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.10.15.28.18.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:3c1ed5864bebd8bb701702e1c632ddf740c570b03e8585e68533eff8260d7119
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.10.15.28.18.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 328888582c2a62de5736073238edbb5e883ffce1
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "272fb8f8e54a406236bbf7f42cabafe568474f46"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3c1ed5864bebd8bb701702e1c632ddf740c570b03e8585e68533eff8260d7119",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.10.15.28.18.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "328888582c2a62de5736073238edbb5e883ffce1"
      }
    },
    "name": "clouddriver-armory"
  }
}
```