### PR TITLE
chore(cd): update echo-armory version to 2022.03.10.16.21.23.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:6ef0d76a9d9ee7bd5876a22eb01dc9ef159767c6b31d003e1d43eb0897346317
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.10.16.21.23.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: cb1f2df110874e9fe30559584110e8265544e53a
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "0e4e085dffd4b05dafcadc32cc78ff82e0a06a7e"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:6ef0d76a9d9ee7bd5876a22eb01dc9ef159767c6b31d003e1d43eb0897346317",
        "repository": "armory/echo-armory",
        "tag": "2022.03.10.16.21.23.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "cb1f2df110874e9fe30559584110e8265544e53a"
      }
    },
    "name": "echo-armory"
  }
}
```