### PR TITLE
chore(cd): update rosco-armory version to 2022.03.10.16.29.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:d79bc7870184f544eece5a00f0a8b19a9605c129f298fa3f12fcca86e663d2f6
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.10.16.29.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 237f8daa9486140e548ac3babed0de8274383a96
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "ed9e8ab4fa236ef2f0c278e15982e4be72467b25"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:d79bc7870184f544eece5a00f0a8b19a9605c129f298fa3f12fcca86e663d2f6",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.10.16.29.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "237f8daa9486140e548ac3babed0de8274383a96"
      }
    },
    "name": "rosco-armory"
  }
}
```