### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.10.16.44.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:9ed2da0f396327e2a565f6baaf20a318d3051851ad56c708cad76cd4fb76565a
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.10.16.44.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: d8d48f82f2424dbca1211a9d16261b4156376eed
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "a29b70a5a7d735707367e22eea64627cbffb266a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:9ed2da0f396327e2a565f6baaf20a318d3051851ad56c708cad76cd4fb76565a",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.10.16.44.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d8d48f82f2424dbca1211a9d16261b4156376eed"
      }
    },
    "name": "clouddriver-armory"
  }
}
```