### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.10.18.01.24.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:b80fc1e64124f304b45a7e9e07f07edfe929407f812d0e840d56389591499b34
+      imageId: sha256:cb72201fb5b13a31582817d1bd3d7d2d0a73d8c34af024fc867935a421c94212
       repository: armory/clouddriver-armory
-      tag: 2022.03.04.23.29.14.release-2.26.x
+      tag: 2022.03.10.18.01.24.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: ab591fae938bd533ef1fd673382c6d7400a6c001
+      sha: 5e845432f05e4b412b060036739ac969dcddfd6f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b809c79086e3eec4752fed77a9d33093ca807c78"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:cb72201fb5b13a31582817d1bd3d7d2d0a73d8c34af024fc867935a421c94212",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.10.18.01.24.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5e845432f05e4b412b060036739ac969dcddfd6f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```