### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.10.18.02.38.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:0fd8765f6b63b60100f1edc952d2e781ca310056575011788546fa9a54ef0568
+      imageId: sha256:14a8156a28afc6a5fb69cc6552b78a9d7cbda1f4a209bb3f740f6f632e4e1a38
       repository: armory/clouddriver-armory
-      tag: 2022.02.24.21.11.22.release-2.25.x
+      tag: 2022.03.10.18.02.38.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 94dfe61e3dceb570f1d478aac9ff73cc7d9ce74a
+      sha: 8fa6d444a3b9e1c785f9c726116744cab2c651f2
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "37f136c789ace6d5f4ae9e58fc9d5847aeabbbeb"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:14a8156a28afc6a5fb69cc6552b78a9d7cbda1f4a209bb3f740f6f632e4e1a38",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.10.18.02.38.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8fa6d444a3b9e1c785f9c726116744cab2c651f2"
      }
    },
    "name": "clouddriver-armory"
  }
}
```