### PR TITLE
chore(cd): update echo-armory version to 2022.03.10.18.15.47.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:883e902ef668cb062518cfea7aa2cb264e20e45bae3ae39a3c50fe88c0a21228
+      imageId: sha256:135a27c1a0a0acaeb40a7ac60f0a7e2d3179c5a187d512db52e0edf54530c2b5
       repository: armory/echo-armory
-      tag: 2022.02.22.22.28.48.release-2.27.x
+      tag: 2022.03.10.18.15.47.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: aa794fa58437bbaae6b3f7c32f4844e5da937c92
+      sha: 57da3b71037bf40657cfe5820bc447e9b2d682a1
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "9fc5d56220a13d43c1ec4c63f719f33ef4fb0b03"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:135a27c1a0a0acaeb40a7ac60f0a7e2d3179c5a187d512db52e0edf54530c2b5",
        "repository": "armory/echo-armory",
        "tag": "2022.03.10.18.15.47.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "57da3b71037bf40657cfe5820bc447e9b2d682a1"
      }
    },
    "name": "echo-armory"
  }
}
```