### PR TITLE
chore(cd): update fiat-armory version to 2022.03.10.19.01.27.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:e7baa558e608356def35a0cc1b3c5f39705a8ece08817b495f3e96f1b78377a0
+      imageId: sha256:c2497ca8658d93cf334364e02a802c452a553dc61f1ea87aa69860e4ea185a39
       repository: armory/fiat-armory
-      tag: 2022.03.07.20.45.34.release-2.25.x
+      tag: 2022.03.10.19.01.27.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 4f831ef52b4de8140965cfaf8917d2ea1ec9097d
+      sha: dd2e9b529657158f32605b7fbd46c43f5e8bc8d2
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "f6b2d8577f9a3120321af9ca9297769fe51288b3"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:c2497ca8658d93cf334364e02a802c452a553dc61f1ea87aa69860e4ea185a39",
        "repository": "armory/fiat-armory",
        "tag": "2022.03.10.19.01.27.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "dd2e9b529657158f32605b7fbd46c43f5e8bc8d2"
      }
    },
    "name": "fiat-armory"
  }
}
```