### PR TITLE
chore(cd): update fiat-armory version to 2022.03.10.19.00.57.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:916ac95044ebef59585fc2a6bf673e67f264acae0247a63bcdb0b1dd0ee69744
+      imageId: sha256:1de1fa92470391530b0322ef8a62957d8e09dd9a0fc97256673ab36ea370d777
       repository: armory/fiat-armory
-      tag: 2022.03.04.23.29.07.release-2.26.x
+      tag: 2022.03.10.19.00.57.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 8f5ecee5cc2eadf18aa2eecbf6fb4c7ffca6e932
+      sha: aab5abd71dd2cc9333707a9018ea13b48aad5054
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "6dad982bdd7af1916f8f55fd2c392050790d10c5"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:1de1fa92470391530b0322ef8a62957d8e09dd9a0fc97256673ab36ea370d777",
        "repository": "armory/fiat-armory",
        "tag": "2022.03.10.19.00.57.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "aab5abd71dd2cc9333707a9018ea13b48aad5054"
      }
    },
    "name": "fiat-armory"
  }
}
```