### PR TITLE
chore(cd): update gate-armory version to 2022.03.10.19.24.10.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:f2355d0c910c627399357177cb9e03508504c203531c82b05d412fc6ca5d8668
+      imageId: sha256:46f1524848bc0e934470392e2cba157d2ba5188f8a16be1e1b7926a3a6033cd2
       repository: armory/gate-armory
-      tag: 2022.02.22.22.40.58.release-2.27.x
+      tag: 2022.03.10.19.24.10.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: f4f1b1c0511d7d20e948541eceb020112acc9f52
+      sha: 61090321ca42d60296d834c9682d7ccc98cc2fc3
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "fcfc26f07b2ded01147c66fdc4fdabf0ca461aa7"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:46f1524848bc0e934470392e2cba157d2ba5188f8a16be1e1b7926a3a6033cd2",
        "repository": "armory/gate-armory",
        "tag": "2022.03.10.19.24.10.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "61090321ca42d60296d834c9682d7ccc98cc2fc3"
      }
    },
    "name": "gate-armory"
  }
}
```