### PR TITLE
chore(cd): update igor-armory version to 2022.03.10.19.54.12.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:d46042429f586410b2cb1996a4bcdfc391cad09df567c0d708c095b0e2c70b58
+      imageId: sha256:f24f1bc3d042cdffbfba6ca8a0f3ffd308af9dd64f6a52c97925a855fcb76899
       repository: armory/igor-armory
-      tag: 2022.02.22.22.48.00.release-2.27.x
+      tag: 2022.03.10.19.54.12.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 97986b3554e3501507989335e73618a832357f71
+      sha: ee3d6a330e2f5a32ff0a64e7dfb65f515666ad51
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "8e17f219cefbcfecf187748f8f4a2c3a9024f7f3"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:f24f1bc3d042cdffbfba6ca8a0f3ffd308af9dd64f6a52c97925a855fcb76899",
        "repository": "armory/igor-armory",
        "tag": "2022.03.10.19.54.12.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "ee3d6a330e2f5a32ff0a64e7dfb65f515666ad51"
      }
    },
    "name": "igor-armory"
  }
}
```