### PR TITLE
chore(cd): update orca-armory version to 2022.03.10.20.21.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:eb849492fadb46387b87acd000dbba746701bc84dcda6602753ec782cf50eb43
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.10.20.21.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 4ad7677a3169f70ff7e243c888e8aa16e7f7e2fa
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "d75a82317daa007b8d79c805d3614cf73d18149c"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:eb849492fadb46387b87acd000dbba746701bc84dcda6602753ec782cf50eb43",
        "repository": "armory/orca-armory",
        "tag": "2022.03.10.20.21.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "4ad7677a3169f70ff7e243c888e8aa16e7f7e2fa"
      }
    },
    "name": "orca-armory"
  }
}
```