### PR TITLE
chore(cd): update rosco-armory version to 2022.03.10.21.05.56.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:e70607b50059c7354cad198eab3a5059bee2dc6116e793864d2cd18e55b3c4b6
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.10.21.05.56.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: c03d8d8b70bab4d3f4e5b83f34a4a1c94ea52667
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "85ffdbc3709b4e5f058c4be5771e82e7d4bf1c0c"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:e70607b50059c7354cad198eab3a5059bee2dc6116e793864d2cd18e55b3c4b6",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.10.21.05.56.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "c03d8d8b70bab4d3f4e5b83f34a4a1c94ea52667"
      }
    },
    "name": "rosco-armory"
  }
}
```