### PR TITLE
chore(cd): update echo-armory version to 2022.03.10.21.44.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:ee6cc7319eb9a2c796b7020a7b25d6659e0d7ab1d4d1436d6d2d5a920850c68c
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.10.21.44.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 490251b3dfce12f241ffe4b746198480eb706da5
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:ee6cc7319eb9a2c796b7020a7b25d6659e0d7ab1d4d1436d6d2d5a920850c68c",
        "repository": "armory/echo-armory",
        "tag": "2022.03.10.21.44.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "490251b3dfce12f241ffe4b746198480eb706da5"
      }
    },
    "name": "echo-armory"
  }
}
```