### PR TITLE
chore(cd): update orca-armory version to 2022.03.10.21.58.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:a4139201bbc11b545bf1d743bc68fb099b25aec3f99151052d44b09615c9932a
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.10.21.58.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: d18ee93ca5c9187dcd70ce16762a3015055b8351
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a4139201bbc11b545bf1d743bc68fb099b25aec3f99151052d44b09615c9932a",
        "repository": "armory/orca-armory",
        "tag": "2022.03.10.21.58.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "d18ee93ca5c9187dcd70ce16762a3015055b8351"
      }
    },
    "name": "orca-armory"
  }
}
```