### PR TITLE
chore(cd): update rosco-armory version to 2022.03.10.22.09.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:1afe454502e7fe0e6738a9edda2a6e0c88f92b951cabf39aef40b3d226f0eb96
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.10.22.09.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: bb65220698400b4a971f6d0970621c231e211490
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "1b4301c55239850d8dd53588d40b3d7f4fabf6f9"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:1afe454502e7fe0e6738a9edda2a6e0c88f92b951cabf39aef40b3d226f0eb96",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.10.22.09.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "bb65220698400b4a971f6d0970621c231e211490"
      }
    },
    "name": "rosco-armory"
  }
}
```