### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.10.22.42.55.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:b704f00158a074b783062edae5f635f2286a94dcd90fc03c6f57aeb77c280cca
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.10.22.42.55.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: b0668f4a4058ecc80440dea9032ff6f98bfccfaf
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "cb445c8c3dddea1c12ace9eccdbd6abc4f730199"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:b704f00158a074b783062edae5f635f2286a94dcd90fc03c6f57aeb77c280cca",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.10.22.42.55.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b0668f4a4058ecc80440dea9032ff6f98bfccfaf"
      }
    },
    "name": "clouddriver-armory"
  }
}
```