### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.10.23.50.12.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:ffa5aa66724251fe7505532ae3a842b23d07d29f36d753678d831c2581426fa5
+      imageId: sha256:cb0d9b5beab392add73dbdf07f5c613b702f5e95067cc262dc75b2a171cb32bd
       repository: armory/clouddriver-armory
-      tag: 2022.03.10.18.01.19.release-2.27.x
+      tag: 2022.03.10.23.50.12.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 2af0e77ea1daf1bd36d56be271391fd1fa3b3a3a
+      sha: e35741acc0994befd5073953f17079548564415f
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ea08cb6813126d7bc90d9c0687fc4afb6ae987b2"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:cb0d9b5beab392add73dbdf07f5c613b702f5e95067cc262dc75b2a171cb32bd",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.10.23.50.12.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e35741acc0994befd5073953f17079548564415f"
      }
    },
    "name": "clouddriver-armory"
  }
}
```