### PR TITLE
chore(cd): update fiat-armory version to 2022.03.11.00.48.17.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:1de1fa92470391530b0322ef8a62957d8e09dd9a0fc97256673ab36ea370d777
+      imageId: sha256:3fb467983d4e182d2f42de5debdfc69d44f7fb32d854b28cd0c915176a7bd69c
       repository: armory/fiat-armory
-      tag: 2022.03.10.19.00.57.release-2.26.x
+      tag: 2022.03.11.00.48.17.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: aab5abd71dd2cc9333707a9018ea13b48aad5054
+      sha: 054b2cde01d10446f58dfa1604d3a0c07a257c13
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "6dad982bdd7af1916f8f55fd2c392050790d10c5"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:3fb467983d4e182d2f42de5debdfc69d44f7fb32d854b28cd0c915176a7bd69c",
        "repository": "armory/fiat-armory",
        "tag": "2022.03.11.00.48.17.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "054b2cde01d10446f58dfa1604d3a0c07a257c13"
      }
    },
    "name": "fiat-armory"
  }
}
```