### PR TITLE
chore(cd): update echo-armory version to 2022.03.11.01.46.39.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:a337ee44fd6c1cd531632ae896f7f44de9b92085add9f23375dd1e95da1908e4
+      imageId: sha256:902a59df6b3708c67ba40067ca38bcf5b909d037dad1932f0041f5cd4e4c730d
       repository: armory/echo-armory
-      tag: 2022.03.11.00.47.06.release-2.26.x
+      tag: 2022.03.11.01.46.39.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: a379ee26ff290520a4dddf2625af9e8aa4160ca5
+      sha: 7da19dfc36ebc5f043d4d69ea1687702761aab18
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:902a59df6b3708c67ba40067ca38bcf5b909d037dad1932f0041f5cd4e4c730d",
        "repository": "armory/echo-armory",
        "tag": "2022.03.11.01.46.39.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "7da19dfc36ebc5f043d4d69ea1687702761aab18"
      }
    },
    "name": "echo-armory"
  }
}
```