### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.11.01.53.42.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:222fe5e576b9d3accb32083ede564089481acf7e9d3e7bae21df04b92e315afb
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.11.01.53.42.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: e7fc673a239f78a8f8b3bed1a746adeca450e913
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "90c8a996003bf6cc64613c1f9b0938065ff3d4bd"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:222fe5e576b9d3accb32083ede564089481acf7e9d3e7bae21df04b92e315afb",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.11.01.53.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e7fc673a239f78a8f8b3bed1a746adeca450e913"
      }
    },
    "name": "clouddriver-armory"
  }
}
```