### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.11.16.06.38.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:0ae59dc932c9bf1acde8b43816872cc233946abeec01cff95ff9449b3009379e
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.11.16.06.38.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 2edce215fb7762b3de2ec8efa993a3f7ef4e2854
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f34fb388d926387959cad32486f64cf7e33842b7"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0ae59dc932c9bf1acde8b43816872cc233946abeec01cff95ff9449b3009379e",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.11.16.06.38.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "2edce215fb7762b3de2ec8efa993a3f7ef4e2854"
      }
    },
    "name": "clouddriver-armory"
  }
}
```