### PR TITLE
chore(cd): update orca-armory version to 2022.03.12.00.05.55.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:055a81794e73c76f88d05a02e4b9707f27a039d9d2436f4aa168752081099e43
+      imageId: sha256:5f15ceffdbe8558bd4c8da8f918f7521d17efb661436f5f5068331cf1232d726
       repository: armory/orca-armory
-      tag: 2022.03.10.20.58.31.release-2.25.x
+      tag: 2022.03.12.00.05.55.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: efaa8bd090343447a9d50f04e45ed1cb70023d5b
+      sha: b9608b22be7fc7aa05e3f178115cb1f6d34d26b8
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "9bb318af6959c3aef39c203d7752c05996713346"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:5f15ceffdbe8558bd4c8da8f918f7521d17efb661436f5f5068331cf1232d726",
        "repository": "armory/orca-armory",
        "tag": "2022.03.12.00.05.55.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "b9608b22be7fc7aa05e3f178115cb1f6d34d26b8"
      }
    },
    "name": "orca-armory"
  }
}
```