### PR TITLE
chore(cd): update echo-armory version to 2022.03.14.22.34.01.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:80c836f1a52a56cdb67f389116190291822ad3251ffd1e8e233403cdeaeac676
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.14.22.34.01.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 2e693c8d0ee4fb8718eaf9d81c256f318fafe764
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "24774bd2557e6c9389b8324dde4b396d2bf11aed"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:80c836f1a52a56cdb67f389116190291822ad3251ffd1e8e233403cdeaeac676",
        "repository": "armory/echo-armory",
        "tag": "2022.03.14.22.34.01.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "2e693c8d0ee4fb8718eaf9d81c256f318fafe764"
      }
    },
    "name": "echo-armory"
  }
}
```