### PR TITLE
chore(cd): update orca-armory version to 2022.03.14.22.41.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:a4cfbb86b81a3041002dab4a169b2c47dceecc1714f715a78d55b3f3db3b8d42
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.14.22.41.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 1e99467d90296403c9b866e5752569fca416b0a4
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "39402cc2f28ede1c5eff1d0c271056e26c955b81"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a4cfbb86b81a3041002dab4a169b2c47dceecc1714f715a78d55b3f3db3b8d42",
        "repository": "armory/orca-armory",
        "tag": "2022.03.14.22.41.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "1e99467d90296403c9b866e5752569fca416b0a4"
      }
    },
    "name": "orca-armory"
  }
}
```