### PR TITLE
chore(cd): update orca-armory version to 2022.03.15.00.13.48.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:99656864f8e3aaa2cc576f862b974b41718b3f0e5b1302218dd1e0d3125181a5
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.15.00.13.48.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 378b01965434751f77d5002487996b59834ad84e
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:99656864f8e3aaa2cc576f862b974b41718b3f0e5b1302218dd1e0d3125181a5",
        "repository": "armory/orca-armory",
        "tag": "2022.03.15.00.13.48.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "378b01965434751f77d5002487996b59834ad84e"
      }
    },
    "name": "orca-armory"
  }
}
```