### PR TITLE
chore(cd): update deck-armory version to 2022.03.15.00.41.18.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:99fe83f5787c2d36731d263daca859e69e60829c31f5c5268c4121a1c996647e
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.15.00.41.18.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: 4c9df591bc5b443312a175bbef0ac74f01d673b7
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "8b967e5f649a2373d704ec1d7d9f790ab1e1802e"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:99fe83f5787c2d36731d263daca859e69e60829c31f5c5268c4121a1c996647e",
        "repository": "armory/deck-armory",
        "tag": "2022.03.15.00.41.18.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "4c9df591bc5b443312a175bbef0ac74f01d673b7"
      }
    },
    "name": "deck-armory"
  }
}
```