### PR TITLE
chore(cd): update deck-armory version to 2022.03.15.21.20.17.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:fde6b765b92d298bf266ef07d2f5353cbd0683e82edaf44b64c7640679a16ba9
+      imageId: sha256:3d50b363b02c3c9c0e96574148190369caef965ceb3f845ef19f2211e928bf0c
       repository: armory/deck-armory
-      tag: 2022.01.25.21.35.37.release-2.26.x
+      tag: 2022.03.15.21.20.17.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 621a865a6130cd00e5bd4dbe2416d0d33be98c37
+      sha: 2d7c85017f177daf233594baff42352fac4556b5
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3d50b363b02c3c9c0e96574148190369caef965ceb3f845ef19f2211e928bf0c",
        "repository": "armory/deck-armory",
        "tag": "2022.03.15.21.20.17.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "2d7c85017f177daf233594baff42352fac4556b5"
      }
    },
    "name": "deck-armory"
  }
}
```