### PR TITLE
chore(cd): update deck-armory version to 2022.03.16.00.08.31.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:98654484281f6467b423c4646d9bebe587b987acd8ec767589fc5d31f8e1d0fd
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.16.00.08.31.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: f0b9487d5482c91965388b42d2569806a99f1281
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "8b967e5f649a2373d704ec1d7d9f790ab1e1802e"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:98654484281f6467b423c4646d9bebe587b987acd8ec767589fc5d31f8e1d0fd",
        "repository": "armory/deck-armory",
        "tag": "2022.03.16.00.08.31.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f0b9487d5482c91965388b42d2569806a99f1281"
      }
    },
    "name": "deck-armory"
  }
}
```