### PR TITLE
chore(cd): update rosco-armory version to 2022.03.16.20.37.23.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:e14d4a42bae1137b85e349f14bb265ed6b34293bf0d55eb1145a4b5892394193
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.16.20.37.23.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 441c034670ecffc09730ec3854cae9f363411e17
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "e942b50f653add47861bba548ee71451ff3c42c8"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:e14d4a42bae1137b85e349f14bb265ed6b34293bf0d55eb1145a4b5892394193",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.16.20.37.23.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "441c034670ecffc09730ec3854cae9f363411e17"
      }
    },
    "name": "rosco-armory"
  }
}
```