### PR TITLE
chore(cd): update echo-armory version to 2022.03.16.21.03.31.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:ef66e3d292a9d99df09c5ea95b7c09f872200d467fd460410ee361d722e3b5bf
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.16.21.03.31.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: 3f5e5b60b451812b871727ff151fd37f25c94681
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:ef66e3d292a9d99df09c5ea95b7c09f872200d467fd460410ee361d722e3b5bf",
        "repository": "armory/echo-armory",
        "tag": "2022.03.16.21.03.31.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "3f5e5b60b451812b871727ff151fd37f25c94681"
      }
    },
    "name": "echo-armory"
  }
}
```