### PR TITLE
chore(cd): update rosco-armory version to 2022.03.17.09.09.50.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:4064d98fc6f0bb9cd26a19433bc4605dfd189454db02592ab66a39b4befd0301
+      imageId: sha256:7d77c9186d7b5d60e766e56d04c92b6a41095be1eacf3d9bdd78fd35e6ca9745
       repository: armory/rosco-armory
-      tag: 2022.03.11.01.50.33.release-2.26.x
+      tag: 2022.03.17.09.09.50.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: a18e8b8faee2c1add1ca74d8e5b16883ad9c9721
+      sha: df08490c4e12feae6fb1860ce37a6f3b05cf9834
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:7d77c9186d7b5d60e766e56d04c92b6a41095be1eacf3d9bdd78fd35e6ca9745",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.17.09.09.50.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "df08490c4e12feae6fb1860ce37a6f3b05cf9834"
      }
    },
    "name": "rosco-armory"
  }
}
```