### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.17.15.57.54.release-2.25.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:bdcf1f18cebb54245d63641605e8d4adc2f8759bf057fe08695591d18c7d8f35
+      imageId: sha256:7c5d176cc4b421dd4c5adf6d2d987b5f22027a77a49eaa2366609f86fba246f5
       repository: armory/clouddriver-armory
-      tag: 2022.03.17.04.46.09.release-2.25.x
+      tag: 2022.03.17.15.57.54.release-2.25.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 1d9d723fffc390c35accbca877e436ce1f28428d
+      sha: 5a71d84bdf803b8ca41d153e30f05b273098b7bf
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.25.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "37f136c789ace6d5f4ae9e58fc9d5847aeabbbeb"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:7c5d176cc4b421dd4c5adf6d2d987b5f22027a77a49eaa2366609f86fba246f5",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.17.15.57.54.release-2.25.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5a71d84bdf803b8ca41d153e30f05b273098b7bf"
      }
    },
    "name": "clouddriver-armory"
  }
}
```