### PR TITLE
chore(cd): update orca-armory version to 2022.03.17.16.11.37.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:1e245ef309dfab8ac86be9d3398b0c41b169e5326ec8f9f24a2634f64712d343
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.17.16.11.37.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 6e6506432f86b4e056fef360522a4fa5570e34fd
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c689089fc2b1f7b4c799e037d87d40aeda141dfe"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:1e245ef309dfab8ac86be9d3398b0c41b169e5326ec8f9f24a2634f64712d343",
        "repository": "armory/orca-armory",
        "tag": "2022.03.17.16.11.37.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "6e6506432f86b4e056fef360522a4fa5570e34fd"
      }
    },
    "name": "orca-armory"
  }
}
```