### PR TITLE
chore(cd): update echo-armory version to 2022.03.17.16.16.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:7d117f0b4138d8f371a6024df2892930334bb4bd8be3f4f6840075b5c4612398
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.17.16.16.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: c543c6c4f6f674cee3e15881af26e3d41b51f537
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "a9b95f7a1329189a0fd95b4f7e5342bb2e37927a"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:7d117f0b4138d8f371a6024df2892930334bb4bd8be3f4f6840075b5c4612398",
        "repository": "armory/echo-armory",
        "tag": "2022.03.17.16.16.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "c543c6c4f6f674cee3e15881af26e3d41b51f537"
      }
    },
    "name": "echo-armory"
  }
}
```