### PR TITLE
chore(cd): update rosco-armory version to 2022.03.17.16.19.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4e732d0fc69a2a567e24e405c1d365a2f8e4555365660d7cc07c1f82537bb61
+      imageId: sha256:77bc74b359ecfa02a2dc904d5903a5403e6e5e24a4132df4eae8b71f38086b13
       repository: armory/rosco-armory
-      tag: 2021.12.17.22.33.05.master
+      tag: 2022.03.17.16.19.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 0dbf1bb5ef37212324e7ea49f6af93744434a39e
+      sha: 082ab4b26788c651bfbb95d0a3f57db1acd1caad
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "788f20426e6cebb11320d6405a33f8d9bd0a84c6"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:77bc74b359ecfa02a2dc904d5903a5403e6e5e24a4132df4eae8b71f38086b13",
        "repository": "armory/rosco-armory",
        "tag": "2022.03.17.16.19.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "082ab4b26788c651bfbb95d0a3f57db1acd1caad"
      }
    },
    "name": "rosco-armory"
  }
}
```