### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.17.16.28.39.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:b2af4ce61a8e6229119c72ed345f2a5f6f61b9d8bcab54f6a84a9fdc57ab7beb
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.17.16.28.39.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 60c86e64f56abcb42481f15572dc68de6de2f646
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "86a14d1251a5266c9a4f504ffdd6ac594ca20635"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:b2af4ce61a8e6229119c72ed345f2a5f6f61b9d8bcab54f6a84a9fdc57ab7beb",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.17.16.28.39.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "60c86e64f56abcb42481f15572dc68de6de2f646"
      }
    },
    "name": "clouddriver-armory"
  }
}
```