### PR TITLE
chore(cd): update orca-armory version to 2022.03.17.19.35.13.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:b20913335eabf47351fddc6e6c482676148f71c68f9d3a614da08d6d5929c18a
+      imageId: sha256:5a08f0fe22d035f7252f6b2a32c23068993257a566ad04ae862e168976f4502f
       repository: armory/orca-armory
-      tag: 2022.03.17.00.40.15.release-2.27.x
+      tag: 2022.03.17.19.35.13.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 88c44710211d05fb1c5fce3f96dafd76748e1e91
+      sha: 29564d884403dbedbefffba9d8523a2ced4983ac
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "981bef83c47ed2e48a18ce18407f2fdaed0f89c9"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:5a08f0fe22d035f7252f6b2a32c23068993257a566ad04ae862e168976f4502f",
        "repository": "armory/orca-armory",
        "tag": "2022.03.17.19.35.13.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "29564d884403dbedbefffba9d8523a2ced4983ac"
      }
    },
    "name": "orca-armory"
  }
}
```