### PR TITLE
chore(cd): update igor-armory version to 2022.03.21.19.00.03.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:ccf41cc09ff57b0bdc76fb31b407d7e9d613658dde2c7b16849b13e24e4adfd4
+      imageId: sha256:bd64b6ee1a3168803782e87d8814b77275d43b8b7e73612585f222172a047152
       repository: armory/igor-armory
-      tag: 2022.03.17.19.29.59.release-2.27.x
+      tag: 2022.03.21.19.00.03.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: f11df55a9398f4efbc641e85afde34fdccbed3a2
+      sha: 0cf17b35a938f66049a0e511199310b2196c5344
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "5807198e8fd2a6f5f9cf59409c2687b4a4f388b6"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:bd64b6ee1a3168803782e87d8814b77275d43b8b7e73612585f222172a047152",
        "repository": "armory/igor-armory",
        "tag": "2022.03.21.19.00.03.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "0cf17b35a938f66049a0e511199310b2196c5344"
      }
    },
    "name": "igor-armory"
  }
}
```