### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.22.17.02.43.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:9dcf00e299d80f486a65554ba8a3f2e3669b5520ee79f770297fff3edd58886b
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.22.17.02.43.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: b7c9e2d0010959d52b9e5e93dd98859fecd4289b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b89f420f7ade3018530c213b5b4a66802a8138e9"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:9dcf00e299d80f486a65554ba8a3f2e3669b5520ee79f770297fff3edd58886b",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.22.17.02.43.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b7c9e2d0010959d52b9e5e93dd98859fecd4289b"
      }
    },
    "name": "clouddriver-armory"
  }
}
```