### PR TITLE
chore(cd): update deck-armory version to 2022.03.22.18.54.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:883081d3db8aa70245b51fbca46bee631ac170ad0cd949bacc365096f5d0904b
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.22.18.54.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: 673706a4425244e96d18cc98f1bb05fad23c78ef
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "45cf778af2e6cb9ba9136689f52d31ce6f68b7c0"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:883081d3db8aa70245b51fbca46bee631ac170ad0cd949bacc365096f5d0904b",
        "repository": "armory/deck-armory",
        "tag": "2022.03.22.18.54.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "673706a4425244e96d18cc98f1bb05fad23c78ef"
      }
    },
    "name": "deck-armory"
  }
}
```