### PR TITLE
chore(cd): update deck-armory version to 2022.03.22.21.43.35.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:9cc00856454ab71b01a46b581d05b03758596c51dafe149ead24edd896abf2e2
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.22.21.43.35.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: 5450b9bfcd78353ba0e952f3c8d00dc17eed4776
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "f5fe6c22a8ed3f8d994dc215b75acf6da08122e5"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:9cc00856454ab71b01a46b581d05b03758596c51dafe149ead24edd896abf2e2",
        "repository": "armory/deck-armory",
        "tag": "2022.03.22.21.43.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "5450b9bfcd78353ba0e952f3c8d00dc17eed4776"
      }
    },
    "name": "deck-armory"
  }
}
```