### PR TITLE
chore(cd): update deck-armory version to 2022.03.22.23.14.23.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:b7078114834b140e5883b4efbbcfd98db72ebb06170101d4c196978400962ceb
+      imageId: sha256:53ab7acf0d68cf99b764dc948300542c9227c9ff61ae8e24c6bf72d8e8c36e72
       repository: armory/deck-armory
-      tag: 2022.03.17.18.45.23.release-2.27.x
+      tag: 2022.03.22.23.14.23.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6da861c96ef96fa8320889668ad57b600ea53a0b
+      sha: 1a8a461d4f65c4ab3adb449f45c66c788aea3ca6
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "b725a6fb8d6d57770a7666f16754392fed99bac2"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:53ab7acf0d68cf99b764dc948300542c9227c9ff61ae8e24c6bf72d8e8c36e72",
        "repository": "armory/deck-armory",
        "tag": "2022.03.22.23.14.23.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "1a8a461d4f65c4ab3adb449f45c66c788aea3ca6"
      }
    },
    "name": "deck-armory"
  }
}
```