### PR TITLE
chore(cd): update echo-armory version to 2022.03.23.19.00.12.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:917b6836d0072d8d9552ca1e58364412fd6029765d84c5df1ec732336d1a02f4
+      imageId: sha256:c6e32343f2fbdc908ae19305c595a21225828e33e392c7b534a97f6617006c50
       repository: armory/echo-armory
-      tag: 2022.01.05.00.44.57.master
+      tag: 2022.03.23.19.00.12.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 76d6578d79fcd5a3776334b005977d7419d55313
+      sha: f5c85b2823ea468043137063843d716d4c3d3d9f
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "ab2494028eaee6f61cf0c10e0deef00cd49f6432"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:c6e32343f2fbdc908ae19305c595a21225828e33e392c7b534a97f6617006c50",
        "repository": "armory/echo-armory",
        "tag": "2022.03.23.19.00.12.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "f5c85b2823ea468043137063843d716d4c3d3d9f"
      }
    },
    "name": "echo-armory"
  }
}
```