### PR TITLE
chore(cd): update front50-armory version to 2022.03.23.19.03.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7d92404ffcaeb982f49b621f388c538cac0d60f3396c662b8713921bb12bb7bd
+      imageId: sha256:36dae64c8990658cbaeccb2b55c035da52eeb305c82ff65f1cf60d3c31299214
       repository: armory/front50-armory
-      tag: 2021.08.04.16.49.32.master
+      tag: 2022.03.23.19.03.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 6b8865fb5eab3c0461f18bd2f4b8b31fcb4df6c9
+      sha: 3526a6d9c86f5b207a5c3c2c980932e727fac433
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "85b8c530b28116599ddc2049acc269c290d857b0"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:36dae64c8990658cbaeccb2b55c035da52eeb305c82ff65f1cf60d3c31299214",
        "repository": "armory/front50-armory",
        "tag": "2022.03.23.19.03.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "3526a6d9c86f5b207a5c3c2c980932e727fac433"
      }
    },
    "name": "front50-armory"
  }
}
```