### PR TITLE
chore(cd): update orca-armory version to 2022.03.23.19.15.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:3a2407a9ce798ec48827765801da43446c437b0959147a5274cd6ddb9d5fd009
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.23.19.15.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 3c64663edfb28eace878d4957fdf8cb377b3e493
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "aad12b4f057a4198b90f9c9c23223f85034e5fe9"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:3a2407a9ce798ec48827765801da43446c437b0959147a5274cd6ddb9d5fd009",
        "repository": "armory/orca-armory",
        "tag": "2022.03.23.19.15.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "3c64663edfb28eace878d4957fdf8cb377b3e493"
      }
    },
    "name": "orca-armory"
  }
}
```