### PR TITLE
chore(cd): update deck-armory version to 2022.03.23.21.36.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:95361ef7a491434744163db8a3010755e73cb10bf025b7c3d2807defea84c904
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.23.21.36.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: 75d3d05020b2d76968c6b36033202c11d89f9f6f
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "c8fc2e60ffad142cce66e189bb4db8954568a051"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:95361ef7a491434744163db8a3010755e73cb10bf025b7c3d2807defea84c904",
        "repository": "armory/deck-armory",
        "tag": "2022.03.23.21.36.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "75d3d05020b2d76968c6b36033202c11d89f9f6f"
      }
    },
    "name": "deck-armory"
  }
}
```