### PR TITLE
chore(cd): update deck-armory version to 2022.03.23.22.09.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:1c8aeba6b6a28b57de845a8fcbd6a75c71ccadb31e81741c710dd11eb8d1a458
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.23.22.09.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: de65d021a695932f98f15211f11406b06a1dd4e4
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "a27e78d423f41d01c6ae0dec4dca9e0b3c5cb6ff"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:1c8aeba6b6a28b57de845a8fcbd6a75c71ccadb31e81741c710dd11eb8d1a458",
        "repository": "armory/deck-armory",
        "tag": "2022.03.23.22.09.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "de65d021a695932f98f15211f11406b06a1dd4e4"
      }
    },
    "name": "deck-armory"
  }
}
```