### PR TITLE
chore(cd): update clouddriver-armory version to 2022.03.23.22.27.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:3a096753f64a24df371fb3b54359aa95c4fe05aa67eb1e36679ae2cadfc37501
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.03.23.22.27.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: a2bfcffe0a05a60ce438dbb46805df9026457a80
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "da657157d6f8c7050ee577e147db99c9936b0b72"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3a096753f64a24df371fb3b54359aa95c4fe05aa67eb1e36679ae2cadfc37501",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.03.23.22.27.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a2bfcffe0a05a60ce438dbb46805df9026457a80"
      }
    },
    "name": "clouddriver-armory"
  }
}
```