### PR TITLE
chore(cd): update deck-armory version to 2022.03.23.22.33.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:fc326a6f25c3fa868addec61bf1877db97636f4f4f3c44c79260a7af256c8697
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.23.22.33.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: f2bb7d626531c214dee79e2757b7ae7f446d6f78
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "1c7614c9479f089d966378e4f1ae9c7aa14502bf"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:fc326a6f25c3fa868addec61bf1877db97636f4f4f3c44c79260a7af256c8697",
        "repository": "armory/deck-armory",
        "tag": "2022.03.23.22.33.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "f2bb7d626531c214dee79e2757b7ae7f446d6f78"
      }
    },
    "name": "deck-armory"
  }
}
```