### PR TITLE
chore(cd): update orca-armory version to 2022.03.24.00.50.30.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:3fe8dd60792e244a4db380fe98466b5094ea992af37ea8bbac6f189169b3fd3b
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.03.24.00.50.30.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: d19a342ecc7e956424517344b1b5a92d4d864a3e
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "31e10a1cdf58e85cc436bd8a919ccadad7fbfedf"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:3fe8dd60792e244a4db380fe98466b5094ea992af37ea8bbac6f189169b3fd3b",
        "repository": "armory/orca-armory",
        "tag": "2022.03.24.00.50.30.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "d19a342ecc7e956424517344b1b5a92d4d864a3e"
      }
    },
    "name": "orca-armory"
  }
}
```