### PR TITLE
chore(cd): update deck-armory version to 2022.03.24.09.08.14.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:18ca6cb6a603f838ca93cfe4a0842e0a61356a17d465d4140e7928ee5e11b3cd
+      imageId: sha256:e420cf59df863af3d9a213e958ddaa1d97c42b76235f01fa6641f859b51a9a81
       repository: armory/deck-armory
-      tag: 2022.01.19.21.37.51.master
+      tag: 2022.03.24.09.08.14.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 6698d11a99199187680bef52bfc8655d6e708306
+      sha: fc550ba9099e491e50b94de431c5571dfdc6fc7e
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "1c7614c9479f089d966378e4f1ae9c7aa14502bf"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:e420cf59df863af3d9a213e958ddaa1d97c42b76235f01fa6641f859b51a9a81",
        "repository": "armory/deck-armory",
        "tag": "2022.03.24.09.08.14.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "fc550ba9099e491e50b94de431c5571dfdc6fc7e"
      }
    },
    "name": "deck-armory"
  }
}
```