### PR TITLE
chore(cd): update fiat-armory version to 2022.03.29.16.27.52.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
+      imageId: sha256:67184082d1b1c83d784d50b9ee40128d9c5ef7168d8fd02f8ce01bae4b50be6c
       repository: armory/fiat-armory
-      tag: 2021.12.17.22.26.27.master
+      tag: 2022.03.29.16.27.52.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
+      sha: 15acc8d797026e96d94bd0c07f45dfb4872c6fad
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "b6ea745a76b77fef23d9555cd2f299293a5a83b3"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:67184082d1b1c83d784d50b9ee40128d9c5ef7168d8fd02f8ce01bae4b50be6c",
        "repository": "armory/fiat-armory",
        "tag": "2022.03.29.16.27.52.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "15acc8d797026e96d94bd0c07f45dfb4872c6fad"
      }
    },
    "name": "fiat-armory"
  }
}
```