### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.01.16.13.58.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:44f8d7f465aad62187de2e5197b5354679de568b75e3d014a9741fd8df4c33b2
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.04.01.16.13.58.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: b430b2d04aac5e0547af9648ae4e0e4186206497
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8b87454e6ba328bc3273e833ac30b16844db2ae1"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:44f8d7f465aad62187de2e5197b5354679de568b75e3d014a9741fd8df4c33b2",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.01.16.13.58.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "b430b2d04aac5e0547af9648ae4e0e4186206497"
      }
    },
    "name": "clouddriver-armory"
  }
}
```