### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.01.18.56.54.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:9445d577bd7edda5aace134941741bdae77bf2a68c8868a40e325ccf8ec79329
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.04.01.18.56.54.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: e1d0eb4e5eadf5f4dbb1caf08db84bf23c6971a6
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6a02194ff5f27cc0d0a774f60d071a976a8a0749"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:9445d577bd7edda5aace134941741bdae77bf2a68c8868a40e325ccf8ec79329",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.01.18.56.54.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e1d0eb4e5eadf5f4dbb1caf08db84bf23c6971a6"
      }
    },
    "name": "clouddriver-armory"
  }
}
```