### PR TITLE
chore(cd): update fiat-armory version to 2022.04.01.20.17.19.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d888200e5e20cf9ad8b72218871e9d2a40f03278fe24502241b1b971b490a34c
+      imageId: sha256:93c44a33925b32b0321b0ded8c9e8f30f28bcffcd735d4aadaf9ecd251d4bb81
       repository: armory/fiat-armory
-      tag: 2021.12.17.22.26.27.master
+      tag: 2022.04.01.20.17.19.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: c74737d58ec81f6a70e7d307d0ba62b28fb93833
+      sha: badafd1ed71b6a9156709d88b1750e5070953ca1
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "dd191f0e385c3f755abeffacf7bdc336a335d608"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:93c44a33925b32b0321b0ded8c9e8f30f28bcffcd735d4aadaf9ecd251d4bb81",
        "repository": "armory/fiat-armory",
        "tag": "2022.04.01.20.17.19.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "badafd1ed71b6a9156709d88b1750e5070953ca1"
      }
    },
    "name": "fiat-armory"
  }
}
```