### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.01.23.39.30.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:1d4ac7e9d937289301af1a6603fb087f56913a63626e6b01fab03c53917fedb4
+      imageId: sha256:ec096f8a9431d74c9db9ee38bde70f9a5911864e4f481f9452c5494e958ee596
       repository: armory/clouddriver-armory
-      tag: 2022.03.21.23.58.58.release-2.27.x
+      tag: 2022.04.01.23.39.30.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: a4ecbb3f5909fc27031f83e9e6bc5eb0bd48e412
+      sha: 19ba7b6af918d90ad97ee8633ec1f898ea02f155
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "db183763708e67720372b34dba87e4d713b0663c"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:ec096f8a9431d74c9db9ee38bde70f9a5911864e4f481f9452c5494e958ee596",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.01.23.39.30.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "19ba7b6af918d90ad97ee8633ec1f898ea02f155"
      }
    },
    "name": "clouddriver-armory"
  }
}
```