### PR TITLE
chore(cd): update front50-armory version to 2022.04.01.23.55.36.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:94a126a666318fa68dbc2d7edc6266b32e74c116e7f802e873fbc7e5f78cfedb
+      imageId: sha256:52f6826714c4c997e9bd4a729813b080572c2a2767630a1a136119cf4bcc89d4
       repository: armory/front50-armory
-      tag: 2022.04.01.23.28.57.release-2.27.x
+      tag: 2022.04.01.23.55.36.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: ea9bb4a7c20fd81050e4fe38e3ed708de66d3f7f
+      sha: dd6b37a42bd76f391d0750407916d2d264aac9a8
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "dd27dfe8541f6cee0216a07e62ec20d1a9525aa8"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:52f6826714c4c997e9bd4a729813b080572c2a2767630a1a136119cf4bcc89d4",
        "repository": "armory/front50-armory",
        "tag": "2022.04.01.23.55.36.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "dd6b37a42bd76f391d0750407916d2d264aac9a8"
      }
    },
    "name": "front50-armory"
  }
}
```