### PR TITLE
chore(cd): update orca-armory version to 2022.04.01.23.57.59.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:af86d5d0fabbc1dc22b2212696deb1c68e95bc051b5872c58115d9a4ec171670
+      imageId: sha256:b99af174ae81ce6c3d1681cf65794f27227973f0f15736a69b2a6e6ef7a61bf3
       repository: armory/orca-armory
-      tag: 2022.03.21.18.58.38.release-2.27.x
+      tag: 2022.04.01.23.57.59.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 0f0798aca2763853efd40f40b7a29bd877ed2808
+      sha: 42f4bbeb9bb226bf738c0882320f879d22a272c4
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "63ada85fa0b81e91476743c8b85da119e5439137"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:b99af174ae81ce6c3d1681cf65794f27227973f0f15736a69b2a6e6ef7a61bf3",
        "repository": "armory/orca-armory",
        "tag": "2022.04.01.23.57.59.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "42f4bbeb9bb226bf738c0882320f879d22a272c4"
      }
    },
    "name": "orca-armory"
  }
}
```