### PR TITLE
chore(cd): update orca-armory version to 2022.04.02.00.13.46.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:b99af174ae81ce6c3d1681cf65794f27227973f0f15736a69b2a6e6ef7a61bf3
+      imageId: sha256:8db53e545a61e42c053c190e75f2c570809d4f42ebbc0c396af76021737f51a9
       repository: armory/orca-armory
-      tag: 2022.04.01.23.57.59.release-2.27.x
+      tag: 2022.04.02.00.13.46.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 42f4bbeb9bb226bf738c0882320f879d22a272c4
+      sha: 0de81de892a0eb8a581efbff2d63170d9b6668ec
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:8db53e545a61e42c053c190e75f2c570809d4f42ebbc0c396af76021737f51a9",
        "repository": "armory/orca-armory",
        "tag": "2022.04.02.00.13.46.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "0de81de892a0eb8a581efbff2d63170d9b6668ec"
      }
    },
    "name": "orca-armory"
  }
}
```