### PR TITLE
chore(cd): update front50-armory version to 2022.04.02.22.19.50.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:94a126a666318fa68dbc2d7edc6266b32e74c116e7f802e873fbc7e5f78cfedb
+      imageId: sha256:47aa78c06356ae68dcec50d64babe738c23645543892b0533de7fd3977b27fc5
       repository: armory/front50-armory
-      tag: 2022.04.01.23.28.57.release-2.27.x
+      tag: 2022.04.02.22.19.50.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: ea9bb4a7c20fd81050e4fe38e3ed708de66d3f7f
+      sha: 86f359fe3a3d0f8876c551c6236a586351e8db85
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "7fbae17b319979b06221789e34f9c354ad782695"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:47aa78c06356ae68dcec50d64babe738c23645543892b0533de7fd3977b27fc5",
        "repository": "armory/front50-armory",
        "tag": "2022.04.02.22.19.50.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "86f359fe3a3d0f8876c551c6236a586351e8db85"
      }
    },
    "name": "front50-armory"
  }
}
```