### PR TITLE
chore(cd): update orca-armory version to 2022.04.04.16.22.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:a07f498bda756da05e413592a551fe9fb3cba8c6ef17c2c7520636cfe1f6a586
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.04.04.16.22.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: 238fc61ed93dd33702377f756455b44fff5acb5d
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "28cc49b74f71736d3c2564d6dbbb0299db4d1e5a"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a07f498bda756da05e413592a551fe9fb3cba8c6ef17c2c7520636cfe1f6a586",
        "repository": "armory/orca-armory",
        "tag": "2022.04.04.16.22.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "238fc61ed93dd33702377f756455b44fff5acb5d"
      }
    },
    "name": "orca-armory"
  }
}
```