### PR TITLE
chore(cd): update orca-armory version to 2022.04.04.21.34.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:0b2a2fdfe2325369e13f16fadb0cb0fd7b715ec97b19e5f539df364ac46ba92c
+      imageId: sha256:e9ee17716f9c8b5c19f63e5615ae1fdc0caba98e7e83868e18c66a667f677281
       repository: armory/orca-armory
-      tag: 2022.01.03.17.50.53.master
+      tag: 2022.04.04.21.34.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 4099cf9f8dfe87642973c21ddfb4498d44f720ce
+      sha: b303904021d518f2d32c167818cea3f3ab5969c4
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "b10b87bbff49b860bd5ca87d1c648535fa21ae30"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:e9ee17716f9c8b5c19f63e5615ae1fdc0caba98e7e83868e18c66a667f677281",
        "repository": "armory/orca-armory",
        "tag": "2022.04.04.21.34.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "b303904021d518f2d32c167818cea3f3ab5969c4"
      }
    },
    "name": "orca-armory"
  }
}
```