### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.04.21.47.51.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:c2045335e1fbbe44bb57957f3ddd860eedcdc285e4fe452c9aa9f4b321b023db
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.04.04.21.47.51.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 555d5284b72c386ef1ee884f050cf08f969c9397
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "f630f0abb9eedcfe160543959a3f1cbb885c8fae"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c2045335e1fbbe44bb57957f3ddd860eedcdc285e4fe452c9aa9f4b321b023db",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.04.21.47.51.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "555d5284b72c386ef1ee884f050cf08f969c9397"
      }
    },
    "name": "clouddriver-armory"
  }
}
```