### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.08.15.22.17.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3eea7a4e96777ca92e2b6f48a69e0ff26cfed91964897e34163b92d5084bb50a
+      imageId: sha256:2228f33322b7db666ae324e7b096986a5efc2d1f78e529649f91d40c1da8bdcd
       repository: armory/clouddriver-armory
-      tag: 2022.01.07.23.40.35.master
+      tag: 2022.04.08.15.22.17.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e71d3b5f4a2cef0ea41739e7658a25cc7de81b8a
+      sha: 69a4d382fdad388fe08ce675549df67c65d9d9c5
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "fb6db8354ef3a7cda56d6a8f36fc4a53fb523330"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:2228f33322b7db666ae324e7b096986a5efc2d1f78e529649f91d40c1da8bdcd",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.08.15.22.17.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "69a4d382fdad388fe08ce675549df67c65d9d9c5"
      }
    },
    "name": "clouddriver-armory"
  }
}
```