### PR TITLE
chore(cd): update deck-armory version to 2022.03.24.09.08.14.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,9 +14,9 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:e420cf59df863af3d9a213e958ddaa1d97c42b76235f01fa6641f859b51a9a81
+      imageId: sha256:84e8ddea1477b943f63d3e4200c225de242e6c9d8c663369d3b022837bb3e70e
       repository: armory/deck-armory
-      tag: 2022.03.24.09.08.14.master
+      tag: 2022.03.24.09.08.14.release-2.28.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "1c7614c9479f089d966378e4f1ae9c7aa14502bf"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:84e8ddea1477b943f63d3e4200c225de242e6c9d8c663369d3b022837bb3e70e",
        "repository": "armory/deck-armory",
        "tag": "2022.03.24.09.08.14.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "fc550ba9099e491e50b94de431c5571dfdc6fc7e"
      }
    },
    "name": "deck-armory"
  }
}
```