### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.09.01.01.55.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:e080b23a854ee4135d964109d96f4d88a2fc04ed596416ae5642f38898d0752f
+      imageId: sha256:fe000e1b8b1d90ab7ab629cbd1d6a5d25d19d6cd5af8ea5c4f652cbcee0d80c2
       repository: armory/clouddriver-armory
-      tag: 2022.04.04.17.17.42.release-2.28.x
+      tag: 2022.04.09.01.01.55.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 5094f98634be982623dd96e959238c6e26fc8d1f
+      sha: 72c785a8b869c9f34c00b2f34e71745ac4f8bd5c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "4457080862bf665e8a7094ccfeaa792906c81f82"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:fe000e1b8b1d90ab7ab629cbd1d6a5d25d19d6cd5af8ea5c4f652cbcee0d80c2",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.09.01.01.55.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "72c785a8b869c9f34c00b2f34e71745ac4f8bd5c"
      }
    },
    "name": "clouddriver-armory"
  }
}
```