### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.12.16.01.42.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:0af0f816c9391ec28a6fc7e733e4d3d72d49f046a625f7dfc1cb14c126a51c8c
+      imageId: sha256:5decf0bca884ad021dcf9ddace5b1ec47159225ee449b6a9ded2376be183831c
       repository: armory/clouddriver-armory
-      tag: 2022.04.09.03.15.10.release-2.28.x
+      tag: 2022.04.12.16.01.42.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 72d3733d662a0f62fcf3102a71a02fa1439f6bf1
+      sha: 27da2fca595ca0825662ab4f3c94e73de3491e98
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "5d8789f8d9a0287f11d73c5abdc63d32af3721fc"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:5decf0bca884ad021dcf9ddace5b1ec47159225ee449b6a9ded2376be183831c",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.12.16.01.42.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "27da2fca595ca0825662ab4f3c94e73de3491e98"
      }
    },
    "name": "clouddriver-armory"
  }
}
```