### PR TITLE
chore(cd): update gate-armory version to 2022.04.20.15.37.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -72,19 +72,19 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
-      imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
+      imageId: sha256:73e9314af23198a10418e89823215c45bf0a4253e8bbc9f1c39f6297b83147f8
       repository: armory/gate-armory
-      tag: 2022.04.08.21.04.38.master
+      tag: 2022.04.20.15.37.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
+      sha: c2dfa524b3e2e37519b10c47b17886f8f2562488
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "3770d149f9fe3ba9eff2cc1bd6025078052a9308"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:73e9314af23198a10418e89823215c45bf0a4253e8bbc9f1c39f6297b83147f8",
        "repository": "armory/gate-armory",
        "tag": "2022.04.20.15.37.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "c2dfa524b3e2e37519b10c47b17886f8f2562488"
      }
    },
    "name": "gate-armory"
  }
}
```