### PR TITLE
chore(cd): update echo-armory version to 2022.04.21.22.19.24.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:1bbad817db5582580cb1d35327be022ffa09046c8dc2bbe7e990d3ae95d8a7ab
+      imageId: sha256:3d688b81cfff617bec55e41894f96a9602d0818697b7c5ed132d75f67eeeeec2
       repository: armory/echo-armory
-      tag: 2022.04.01.15.52.33.master
+      tag: 2022.04.21.22.19.24.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 6fdec1161400339884e461987b30d22ff1295e98
+      sha: e08f5cc6de06c96e5753fb43397cd41aea7378c9
   fiat-armory:
     baseService: fiat
     image:
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "37bbfdb79ab27d5f11fd4e0165beb9899ee04348"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:3d688b81cfff617bec55e41894f96a9602d0818697b7c5ed132d75f67eeeeec2",
        "repository": "armory/echo-armory",
        "tag": "2022.04.21.22.19.24.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "e08f5cc6de06c96e5753fb43397cd41aea7378c9"
      }
    },
    "name": "echo-armory"
  }
}
```