### PR TITLE
chore(cd): update fiat-armory version to 2022.04.21.22.19.29.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:3331085e5900c2af7f2b3a3cf839e4ccdfe5c0ecd8388c19cfcc9267bc7daa8b
+      imageId: sha256:b8d23420f3a22016fff35dcc2b71509a608155a247a3dd5d710fdd0901b0c1b8
       repository: armory/fiat-armory
-      tag: 2022.04.01.22.18.04.master
+      tag: 2022.04.21.22.19.29.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 2fc6f1b7b103475fff7753314759b693bcebe331
+      sha: 6bc91df8b981f0d37811751c8d27a5f88f44db3c
   front50-armory:
     baseService: front50
     image:
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "2c25f8e82ef11ac7c92252b7845c6eebc4d17d52"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:b8d23420f3a22016fff35dcc2b71509a608155a247a3dd5d710fdd0901b0c1b8",
        "repository": "armory/fiat-armory",
        "tag": "2022.04.21.22.19.29.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "6bc91df8b981f0d37811751c8d27a5f88f44db3c"
      }
    },
    "name": "fiat-armory"
  }
}
```