### PR TITLE
chore(cd): update rosco-armory version to 2022.04.26.00.30.50.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:ac383ed074df1d2f3fc9a14ee84e3f45fb59f74dca1e3d62fa0f0dc80963cf63
+      imageId: sha256:f32afd7bcd7dd6f7eb05df49331ba4b16e1732034bfb38bc0042352ef9b8fead
       repository: armory/rosco-armory
-      tag: 2022.04.01.15.50.46.release-2.28.x
+      tag: 2022.04.26.00.30.50.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 06f25d3966952226e8ec90084bc29da3602602d9
+      sha: b2a9b91702994c5bec2e3a9763095da72fcee7f0
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "074198ae910104c93026ffd65eb50b1106cb1431"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:f32afd7bcd7dd6f7eb05df49331ba4b16e1732034bfb38bc0042352ef9b8fead",
        "repository": "armory/rosco-armory",
        "tag": "2022.04.26.00.30.50.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "b2a9b91702994c5bec2e3a9763095da72fcee7f0"
      }
    },
    "name": "rosco-armory"
  }
}
```