### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.26.00.29.23.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:5decf0bca884ad021dcf9ddace5b1ec47159225ee449b6a9ded2376be183831c
+      imageId: sha256:c8ec8efaf01f2146efe1c78107027dbe7b0bf942af38a67ab0c500c1a3e2020a
       repository: armory/clouddriver-armory
-      tag: 2022.04.12.16.01.42.release-2.28.x
+      tag: 2022.04.26.00.29.23.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 27da2fca595ca0825662ab4f3c94e73de3491e98
+      sha: 52b177759f821678ded376951a654721fee635b1
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "5d8789f8d9a0287f11d73c5abdc63d32af3721fc"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c8ec8efaf01f2146efe1c78107027dbe7b0bf942af38a67ab0c500c1a3e2020a",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.26.00.29.23.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "52b177759f821678ded376951a654721fee635b1"
      }
    },
    "name": "clouddriver-armory"
  }
}
```