### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.26.15.24.58.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:c8ec8efaf01f2146efe1c78107027dbe7b0bf942af38a67ab0c500c1a3e2020a
+      imageId: sha256:c044b9ca014dcaf4532a77ab9eb4b2f496727c469c993009a3fa685480d35c6a
       repository: armory/clouddriver-armory
-      tag: 2022.04.26.00.29.23.release-2.28.x
+      tag: 2022.04.26.15.24.58.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 52b177759f821678ded376951a654721fee635b1
+      sha: 1bd85640d6ed8b6f5f665d819c859481229e0b96
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d3eba02bb4faa0654f862ca03373d1f87c3bac30"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c044b9ca014dcaf4532a77ab9eb4b2f496727c469c993009a3fa685480d35c6a",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.26.15.24.58.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "1bd85640d6ed8b6f5f665d819c859481229e0b96"
      }
    },
    "name": "clouddriver-armory"
  }
}
```