### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.26.16.10.29.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:c044b9ca014dcaf4532a77ab9eb4b2f496727c469c993009a3fa685480d35c6a
+      imageId: sha256:ccfe92e2fa0cd6a02a01dccda7d065f5901f0858b9b05b3e7786bdc93b55c60d
       repository: armory/clouddriver-armory
-      tag: 2022.04.26.15.24.58.release-2.28.x
+      tag: 2022.04.26.16.10.29.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 1bd85640d6ed8b6f5f665d819c859481229e0b96
+      sha: 691d0701836f5122b94ec8e1da5ccd7e6bdba6cc
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d3eba02bb4faa0654f862ca03373d1f87c3bac30"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:ccfe92e2fa0cd6a02a01dccda7d065f5901f0858b9b05b3e7786bdc93b55c60d",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.26.16.10.29.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "691d0701836f5122b94ec8e1da5ccd7e6bdba6cc"
      }
    },
    "name": "clouddriver-armory"
  }
}
```