### PR TITLE
chore(cd): update igor-armory version to 2022.04.26.17.19.15.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:0ab05599fe167b8e1f0fc4188c002b04a986ed6802ecc7fe035454dbdefffc8a
+      imageId: sha256:c8c83dc7ca0bf7a000f0350075b7a9d68e5e468a0d442a64442a95a3a01fb94f
       repository: armory/igor-armory
-      tag: 2022.04.02.03.10.37.release-2.27.x
+      tag: 2022.04.26.17.19.15.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 94c9f9ff6fa163fae8967ee51a36e01c3cd306d4
+      sha: 1dbf04071495d186f7dbc534ed8c01e68950d29e
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "d17a4467233b85255db8929387f155f1615b74b7"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:c8c83dc7ca0bf7a000f0350075b7a9d68e5e468a0d442a64442a95a3a01fb94f",
        "repository": "armory/igor-armory",
        "tag": "2022.04.26.17.19.15.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "1dbf04071495d186f7dbc534ed8c01e68950d29e"
      }
    },
    "name": "igor-armory"
  }
}
```