### PR TITLE
chore(cd): update front50-armory version to 2022.04.26.17.15.34.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:bfe4de76ab25e8ed3a483251371daca19be1c32697920cc29e448fbfa06a34d2
+      imageId: sha256:bae4e2a74ec680e8dad59d49894fe4b25b039a8fadfb9113b96ce0c210dd5ca8
       repository: armory/front50-armory
-      tag: 2022.04.07.20.10.53.release-2.27.x
+      tag: 2022.04.26.17.15.34.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 3501964fda14592680f9e6d0ceb8515f9224edb1
+      sha: 01f19e9c4cd1d0fc008e5dd740bebcade32ac8af
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "9b7886145d1258d8132a42adf64b57337f7dc0bb"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:bae4e2a74ec680e8dad59d49894fe4b25b039a8fadfb9113b96ce0c210dd5ca8",
        "repository": "armory/front50-armory",
        "tag": "2022.04.26.17.15.34.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "01f19e9c4cd1d0fc008e5dd740bebcade32ac8af"
      }
    },
    "name": "front50-armory"
  }
}
```