### PR TITLE
chore(cd): update orca-armory version to 2022.04.26.17.38.43.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:a7d519daff8e7ecd6100d405ab5f5e120743ef5fba3aa6c02a6213fc5bbff2aa
+      imageId: sha256:726f4d2adbc99434507598850c8d1d4f41210558a0b7fbbcd692909524bbc01b
       repository: armory/orca-armory
-      tag: 2022.04.07.18.16.06.release-2.27.x
+      tag: 2022.04.26.17.38.43.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: ea996bac1fea906a2a4b764e7ea147777db92dc6
+      sha: d2139c21b94f65071c208300abb8edc447ccce69
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "7347918ce38d0a56ebc324f1dbf09ee77f4252ee"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:726f4d2adbc99434507598850c8d1d4f41210558a0b7fbbcd692909524bbc01b",
        "repository": "armory/orca-armory",
        "tag": "2022.04.26.17.38.43.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "d2139c21b94f65071c208300abb8edc447ccce69"
      }
    },
    "name": "orca-armory"
  }
}
```