### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.26.21.37.57.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:f97f54f90ccea666dd0cf92578d4b00a55ae415d0e6f0c85161f1418dcd3d425
+      imageId: sha256:ac46033f5a3fe97f450ab732e63ed6d2578af0f17fa04bfdd831c2794412a512
       repository: armory/clouddriver-armory
-      tag: 2022.04.26.15.35.50.release-2.27.x
+      tag: 2022.04.26.21.37.57.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8eada0fc4aa167bb7d69ed23bcebbe78a766b7bb
+      sha: 6b717a17d201f456a4b4699991e66a6d2bf2572e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "975fdbb57a5353c725db04dc743317646425fff6"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:ac46033f5a3fe97f450ab732e63ed6d2578af0f17fa04bfdd831c2794412a512",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.26.21.37.57.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6b717a17d201f456a4b4699991e66a6d2bf2572e"
      }
    },
    "name": "clouddriver-armory"
  }
}
```