### PR TITLE
chore(cd): update gate-armory version to 2022.04.26.21.36.23.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:3b4fae4cb2345c3b8d6dd180378e96d69278f01888d014f9dc5ba996b5ae9ff2
+      imageId: sha256:be6be3830a1ed4e2f5e6505cf421b102b1acdd4661ac9a37e732894e04a4d4a4
       repository: armory/gate-armory
-      tag: 2022.04.26.17.12.50.release-2.27.x
+      tag: 2022.04.26.21.36.23.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 8c9d3e89206bd809ff4568f421b0278e3b5787d7
+      sha: b139b70d9e376c85c2c3e159b59d17de4b57b10e
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "dba199e7cb2eb1d28192efda6e51b1685b8a3ecf"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:be6be3830a1ed4e2f5e6505cf421b102b1acdd4661ac9a37e732894e04a4d4a4",
        "repository": "armory/gate-armory",
        "tag": "2022.04.26.21.36.23.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "b139b70d9e376c85c2c3e159b59d17de4b57b10e"
      }
    },
    "name": "gate-armory"
  }
}
```