### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.27.04.09.57.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:ccfe92e2fa0cd6a02a01dccda7d065f5901f0858b9b05b3e7786bdc93b55c60d
+      imageId: sha256:f0d5409c95e7592f2df72adb4c2facdac02becd413b21cf605704da30ea2515d
       repository: armory/clouddriver-armory
-      tag: 2022.04.26.16.10.29.release-2.28.x
+      tag: 2022.04.27.04.09.57.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 691d0701836f5122b94ec8e1da5ccd7e6bdba6cc
+      sha: 549a23a10b96ddec8229319de17d1353aa0a8f03
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "6ca647a0269b1c8e28bb2e0b27f3eea8a0459efd"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:f0d5409c95e7592f2df72adb4c2facdac02becd413b21cf605704da30ea2515d",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.27.04.09.57.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "549a23a10b96ddec8229319de17d1353aa0a8f03"
      }
    },
    "name": "clouddriver-armory"
  }
}
```