### PR TITLE
chore(cd): update echo-armory version to 2022.04.27.04.56.18.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:323bc17caeb18f568fc07b0411b9ec634c076661fa443dcbefca424d1a2b87ef
+      imageId: sha256:458b9a507e207b3b8d8753dd7c359688410fc9ddac9ca9f4b73ee8294c4b151f
       repository: armory/echo-armory
-      tag: 2022.04.27.00.27.37.release-2.28.x
+      tag: 2022.04.27.04.56.18.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 78e9f230f7604b4180da9facfb12379ed43a43c2
+      sha: fa6fa41607e5dae90a8b9a1b280214099e193f7a
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "2cbfb86ae84987f8b3456fbb5f278a7a1114aeda"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:458b9a507e207b3b8d8753dd7c359688410fc9ddac9ca9f4b73ee8294c4b151f",
        "repository": "armory/echo-armory",
        "tag": "2022.04.27.04.56.18.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "fa6fa41607e5dae90a8b9a1b280214099e193f7a"
      }
    },
    "name": "echo-armory"
  }
}
```