### PR TITLE
chore(cd): update clouddriver-armory version to 2022.04.27.05.48.50.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:fc7b54f428d1fc04d3f7b141e5ef773ed863b4ea3d5b89d0ad0bf1f6b21f17ea
+      imageId: sha256:14998d0c3ac84bccd194f3a4fd79861581ee9c7d7e48f3220cdef21fbd67c55f
       repository: armory/clouddriver-armory
-      tag: 2022.04.27.04.09.53.release-2.27.x
+      tag: 2022.04.27.05.48.50.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: c0cdf2b0956533e6214567f958a9ed4155b4e9f1
+      sha: 924e80f11e9c7bbcf01c1b818152a50af91721e9
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "17fec14f84c520ef6b393fa81fe0ce1414e4942e"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:14998d0c3ac84bccd194f3a4fd79861581ee9c7d7e48f3220cdef21fbd67c55f",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.04.27.05.48.50.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "924e80f11e9c7bbcf01c1b818152a50af91721e9"
      }
    },
    "name": "clouddriver-armory"
  }
}
```