### PR TITLE
chore(cd): update orca-armory version to 2022.04.27.05.58.47.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:595445dfd674c4f13eb88163d46c1a23c907561a3fee9e24df69f31e084c6bbf
+      imageId: sha256:482b793abe1e653de3f831354fbd9f26b0d7f6703a2452c73c3013db8eb47ed2
       repository: armory/orca-armory
-      tag: 2022.04.26.21.43.12.release-2.27.x
+      tag: 2022.04.27.05.58.47.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: e18acb93b29b58cf27d15e0cbd2cbff38969938c
+      sha: 8f08391eade3decfedec5707fc6dc62fd4d4aea9
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "ac31f337cd0845d10c1474dc8a8cc8df6fdd8862"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:482b793abe1e653de3f831354fbd9f26b0d7f6703a2452c73c3013db8eb47ed2",
        "repository": "armory/orca-armory",
        "tag": "2022.04.27.05.58.47.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "8f08391eade3decfedec5707fc6dc62fd4d4aea9"
      }
    },
    "name": "orca-armory"
  }
}
```