### PR TITLE
chore(cd): update gate-armory version to 2022.04.28.16.50.08.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
+      imageId: sha256:865599c5442543bd30695fea515f5425311929436a94489216a09d791eed0f2c
       repository: armory/gate-armory
-      tag: 2022.04.08.21.04.38.master
+      tag: 2022.04.28.16.50.08.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
+      sha: 7c10887526400192ffb24f0fbb7499b47bd1f5b9
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "d7fcb25c7fcf1f7e73b6f49cb65cc775250bd642"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:865599c5442543bd30695fea515f5425311929436a94489216a09d791eed0f2c",
        "repository": "armory/gate-armory",
        "tag": "2022.04.28.16.50.08.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "7c10887526400192ffb24f0fbb7499b47bd1f5b9"
      }
    },
    "name": "gate-armory"
  }
}
```