### PR TITLE
chore(cd): update orca-armory version to 2022.04.28.20.14.17.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:a07f498bda756da05e413592a551fe9fb3cba8c6ef17c2c7520636cfe1f6a586
+      imageId: sha256:954d6bb86eb90a2f6e3c4f377c6c6d80a15fcd63e93480cb7bd9dbf12c073cce
       repository: armory/orca-armory
-      tag: 2022.04.04.16.22.09.master
+      tag: 2022.04.28.20.14.17.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 238fc61ed93dd33702377f756455b44fff5acb5d
+      sha: 42bbb9d68fa7d338781fe93e7e5b2e792f09eb84
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "337c568ebb361352eac99fa163657cc4574ea372"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:954d6bb86eb90a2f6e3c4f377c6c6d80a15fcd63e93480cb7bd9dbf12c073cce",
        "repository": "armory/orca-armory",
        "tag": "2022.04.28.20.14.17.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "42bbb9d68fa7d338781fe93e7e5b2e792f09eb84"
      }
    },
    "name": "orca-armory"
  }
}
```