### PR TITLE
chore(cd): update fiat-armory version to 2022.04.29.16.28.15.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:3331085e5900c2af7f2b3a3cf839e4ccdfe5c0ecd8388c19cfcc9267bc7daa8b
+      imageId: sha256:24bcaa9b3c714254d3165e383bf58fc668ab7f8fd31f5bc76447de43f3d9446f
       repository: armory/fiat-armory
-      tag: 2022.04.01.22.18.04.master
+      tag: 2022.04.29.16.28.15.master
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 2fc6f1b7b103475fff7753314759b693bcebe331
+      sha: 38978b894d4dc7ec4c773b8432b98aaf648cd86d
   front50-armory:
     baseService: front50
     image:
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "d383865c9794cc0d320bdfa5387df6e079c6ed65"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:24bcaa9b3c714254d3165e383bf58fc668ab7f8fd31f5bc76447de43f3d9446f",
        "repository": "armory/fiat-armory",
        "tag": "2022.04.29.16.28.15.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "38978b894d4dc7ec4c773b8432b98aaf648cd86d"
      }
    },
    "name": "fiat-armory"
  }
}
```