### PR TITLE
chore(cd): update rosco-armory version to 2022.04.29.17.26.17.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:16b41c6908cca03a276d830246ce2b37e5b96c159621279877a7eb07ce1277af
+      imageId: sha256:d5c4a8bd6fefc03b818f3fefa5e7e44ea5479869510d8d01405937c3227718ea
       repository: armory/rosco-armory
-      tag: 2022.04.27.03.37.39.release-2.28.x
+      tag: 2022.04.29.17.26.17.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 469ea3e1a1bf2adfa7303aed5d5c4e75d63e81b4
+      sha: 09098dfa90f88adbc44528d85d71bb0c73b980b4
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "53c66665ec0efa39fc81795cccdf08a72767ec22"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:d5c4a8bd6fefc03b818f3fefa5e7e44ea5479869510d8d01405937c3227718ea",
        "repository": "armory/rosco-armory",
        "tag": "2022.04.29.17.26.17.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "09098dfa90f88adbc44528d85d71bb0c73b980b4"
      }
    },
    "name": "rosco-armory"
  }
}
```