### PR TITLE
chore(cd): update orca-armory version to 2022.04.29.17.57.36.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:954d6bb86eb90a2f6e3c4f377c6c6d80a15fcd63e93480cb7bd9dbf12c073cce
+      imageId: sha256:99a5889913146b0ad3aa96cc9ee0daf0c3a87afb9172daba47f2db96a65046b1
       repository: armory/orca-armory
-      tag: 2022.04.28.20.14.17.release-2.28.x
+      tag: 2022.04.29.17.57.36.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 42bbb9d68fa7d338781fe93e7e5b2e792f09eb84
+      sha: 89182e7ab21b6484960d68600c75c727ea891b05
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "337c568ebb361352eac99fa163657cc4574ea372"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:99a5889913146b0ad3aa96cc9ee0daf0c3a87afb9172daba47f2db96a65046b1",
        "repository": "armory/orca-armory",
        "tag": "2022.04.29.17.57.36.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "89182e7ab21b6484960d68600c75c727ea891b05"
      }
    },
    "name": "orca-armory"
  }
}
```