### PR TITLE
chore(cd): update orca-armory version to 2022.05.02.22.15.58.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:99a5889913146b0ad3aa96cc9ee0daf0c3a87afb9172daba47f2db96a65046b1
+      imageId: sha256:c3ae876d85bc51d1317cfcaaba8961a921f091c7b6e01e316846d4a1b8be8309
       repository: armory/orca-armory
-      tag: 2022.04.29.17.57.36.release-2.28.x
+      tag: 2022.05.02.22.15.58.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 89182e7ab21b6484960d68600c75c727ea891b05
+      sha: 0449e2f4c812d2622c16fb7f441835411d474f8a
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "337c568ebb361352eac99fa163657cc4574ea372"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:c3ae876d85bc51d1317cfcaaba8961a921f091c7b6e01e316846d4a1b8be8309",
        "repository": "armory/orca-armory",
        "tag": "2022.05.02.22.15.58.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "0449e2f4c812d2622c16fb7f441835411d474f8a"
      }
    },
    "name": "orca-armory"
  }
}
```