### PR TITLE
chore(cd): update front50-armory version to 2022.05.02.22.21.42.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:57dd33b0f413e1ce258d1ff37f89de9cf775b12facfe818b8d8c4fa557f84ded
+      imageId: sha256:6c65f8781ab3622efedc5d9697fde84fdd2ee95b6320939bb42cf1d66a9b8804
       repository: armory/front50-armory
-      tag: 2022.04.01.15.54.53.master
+      tag: 2022.05.02.22.21.42.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
+      sha: c4f4a453150a5c9748d7225739ce30d919df02cc
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "9cf7854cd672e89a02797d8796316277fc197a7d"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:6c65f8781ab3622efedc5d9697fde84fdd2ee95b6320939bb42cf1d66a9b8804",
        "repository": "armory/front50-armory",
        "tag": "2022.05.02.22.21.42.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "c4f4a453150a5c9748d7225739ce30d919df02cc"
      }
    },
    "name": "front50-armory"
  }
}
```