### PR TITLE
chore(cd): update igor-armory version to 2022.05.02.22.26.38.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
+      imageId: sha256:20d12e15c9344e1e6393308c74089950c8a7e3b4a3d56d881c25b21961eddc38
       repository: armory/igor-armory
-      tag: 2022.04.08.20.51.51.master
+      tag: 2022.05.02.22.26.38.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: abeae9a43af57715379281715fc6f82e282c28a2
+      sha: 830b9ed090139e3d30725f56d8b8fe266528a1bf
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "0c2da717d35964d50a9aa6322522a5c57002fa73"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:20d12e15c9344e1e6393308c74089950c8a7e3b4a3d56d881c25b21961eddc38",
        "repository": "armory/igor-armory",
        "tag": "2022.05.02.22.26.38.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "830b9ed090139e3d30725f56d8b8fe266528a1bf"
      }
    },
    "name": "igor-armory"
  }
}
```