### PR TITLE
chore(cd): update kayenta-armory version to 2022.05.05.18.34.01.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
+      imageId: sha256:959e102587f64aa8863a9b4d18e5964c7b217bda0025bf2146c4597f8ecad8c0
       repository: armory/kayenta-armory
-      tag: 2022.04.08.20.41.27.master
+      tag: 2022.05.05.18.34.01.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: c41734ba623fbeb358f1b5aae21cba584b092236
+      sha: d286b012b5e51c3d825d467dd73a795d23463575
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "d76525aea1c3619da154032d24c0aef1fbf36994"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:959e102587f64aa8863a9b4d18e5964c7b217bda0025bf2146c4597f8ecad8c0",
        "repository": "armory/kayenta-armory",
        "tag": "2022.05.05.18.34.01.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "d286b012b5e51c3d825d467dd73a795d23463575"
      }
    },
    "name": "kayenta-armory"
  }
}
```