### PR TITLE
chore(cd): update fiat-armory version to 2022.05.11.17.27.50.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:508884ef66466cf6dc6706a4a9c55f1865b20bafc0a912026bdac0bdf0e22674
+      imageId: sha256:81e99ccfc816f504b4741ffcfb5b406efe5c2c4339dc4136a7abb3c1d2707cf7
       repository: armory/fiat-armory
-      tag: 2022.05.02.22.12.34.release-2.28.x
+      tag: 2022.05.11.17.27.50.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: b179e79c40bc1242d58be7900e5595287e4515de
+      sha: cabe7b17a0794213f3b41d0713f3e0163ae719d7
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "ab47389627b9170d512f1bbc73ed1ef80e64859e"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:81e99ccfc816f504b4741ffcfb5b406efe5c2c4339dc4136a7abb3c1d2707cf7",
        "repository": "armory/fiat-armory",
        "tag": "2022.05.11.17.27.50.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "cabe7b17a0794213f3b41d0713f3e0163ae719d7"
      }
    },
    "name": "fiat-armory"
  }
}
```