### PR TITLE
chore(cd): update clouddriver-armory version to 2022.05.16.15.40.48.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:924393a8e0bd6a3b859bcb089f95594e942f1a31d5b1f2efd7d8a6298f1f718e
+      imageId: sha256:5842708b13a7d58824a327a7699735412d2ad002ba9dc4ea5989b3979bb18113
       repository: armory/clouddriver-armory
-      tag: 2022.05.02.22.07.42.release-2.28.x
+      tag: 2022.05.16.15.40.48.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: b9aa28ce70b3da80268659a195ad968a217debfa
+      sha: ae45181b7b23f37c82ad4949fc78a072c7a73d77
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ccf7534b12ac2f6d35c7c15ab62536dbe8421047"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:5842708b13a7d58824a327a7699735412d2ad002ba9dc4ea5989b3979bb18113",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.05.16.15.40.48.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ae45181b7b23f37c82ad4949fc78a072c7a73d77"
      }
    },
    "name": "clouddriver-armory"
  }
}
```