### PR TITLE
chore(cd): update clouddriver-armory version to 2022.05.18.17.33.16.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:9cdf9258c09abcf1283c041462a5a9bb8989e864e12c9ccedfcdeb7532b52841
+      imageId: sha256:e13b693f93bfe5226be90c85143ce788011e5e064debc862d1c6a7ce3e1ed1f8
       repository: armory/clouddriver-armory
-      tag: 2022.05.18.17.00.41.release-2.28.x
+      tag: 2022.05.18.17.33.16.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 6312b579acaa141f6f677cabedacf1f04869bd82
+      sha: d8b26f4c4a92ff7db77472a51cbbc9bf9a7d23a6
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "79531aee41b14b657644161c062cec92f51df39a"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:e13b693f93bfe5226be90c85143ce788011e5e064debc862d1c6a7ce3e1ed1f8",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.05.18.17.33.16.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d8b26f4c4a92ff7db77472a51cbbc9bf9a7d23a6"
      }
    },
    "name": "clouddriver-armory"
  }
}
```