### PR TITLE
chore(cd): update echo-armory version to 2022.05.18.20.57.08.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:878d22dde7c8edee4817a64d643d92b45ff8307a4d0c6390408b99fa230e6c39
+      imageId: sha256:f1c56706c17b3521239424d66aa3e1f6675001373efcc3477429ae2e1dfca123
       repository: armory/echo-armory
-      tag: 2022.05.11.17.19.43.release-2.28.x
+      tag: 2022.05.18.20.57.08.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: d49d6289e66897f00e6a62f065310ee3fe090f77
+      sha: 07633630b58c15b5145cc00af08528f0b2b0607f
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "883deb30c4d2be2b5851ab3a8da60a498cc98079"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:f1c56706c17b3521239424d66aa3e1f6675001373efcc3477429ae2e1dfca123",
        "repository": "armory/echo-armory",
        "tag": "2022.05.18.20.57.08.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "07633630b58c15b5145cc00af08528f0b2b0607f"
      }
    },
    "name": "echo-armory"
  }
}
```