### PR TITLE
chore(cd): update front50-armory version to 2022.05.18.20.57.18.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:343ba72231a41c7d410f24baa35ebc42dbc87b1ee955e36d2a51c38a4a6c0eaf
+      imageId: sha256:ffabd934bf7eaaedfe5716f0ff3bded2eb64b83a05e317bb068ae002e29f45e5
       repository: armory/front50-armory
-      tag: 2022.05.11.20.03.13.release-2.28.x
+      tag: 2022.05.18.20.57.18.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: a1e4e43748ce11e8de85f7d29dfba21d12152d68
+      sha: f818ac4ce606e4b4f74f3cada4f4bc173a949b50
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "9cf7854cd672e89a02797d8796316277fc197a7d"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:ffabd934bf7eaaedfe5716f0ff3bded2eb64b83a05e317bb068ae002e29f45e5",
        "repository": "armory/front50-armory",
        "tag": "2022.05.18.20.57.18.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "f818ac4ce606e4b4f74f3cada4f4bc173a949b50"
      }
    },
    "name": "front50-armory"
  }
}
```