### PR TITLE
chore(cd): update gate-armory version to 2022.05.18.20.57.43.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:d0780e4affc70a78379a86c75a9db5cc41a12dd7b853d8e5b2acd84980c038c8
+      imageId: sha256:c69f270836c0ee9b82f4f7444bfdde25856e3ee890dc20b8f6b3be9f41ad16aa
       repository: armory/gate-armory
-      tag: 2022.05.02.22.15.52.release-2.28.x
+      tag: 2022.05.18.20.57.43.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 5d146a61327665d4c47e8f5c4c51d449627a707d
+      sha: d0761570b845d9dbda0f117ff6f56d78ac203cfb
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "115805786e5e30ec591b077ebad91c2658c4cbf2"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:c69f270836c0ee9b82f4f7444bfdde25856e3ee890dc20b8f6b3be9f41ad16aa",
        "repository": "armory/gate-armory",
        "tag": "2022.05.18.20.57.43.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "d0761570b845d9dbda0f117ff6f56d78ac203cfb"
      }
    },
    "name": "gate-armory"
  }
}
```