### PR TITLE
chore(cd): update fiat-armory version to 2022.05.18.20.56.57.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:81e99ccfc816f504b4741ffcfb5b406efe5c2c4339dc4136a7abb3c1d2707cf7
+      imageId: sha256:d90a0ad93b323721e3a9a3a735675e993fda217e81f38b2af25246d9fb7cbe58
       repository: armory/fiat-armory
-      tag: 2022.05.11.17.27.50.release-2.28.x
+      tag: 2022.05.18.20.56.57.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: cabe7b17a0794213f3b41d0713f3e0163ae719d7
+      sha: 6748c08dc6b2329724076684a66b11ae7f3dce76
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "ab47389627b9170d512f1bbc73ed1ef80e64859e"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:d90a0ad93b323721e3a9a3a735675e993fda217e81f38b2af25246d9fb7cbe58",
        "repository": "armory/fiat-armory",
        "tag": "2022.05.18.20.56.57.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "6748c08dc6b2329724076684a66b11ae7f3dce76"
      }
    },
    "name": "fiat-armory"
  }
}
```