### PR TITLE
chore(cd): update rosco-armory version to 2022.05.18.20.59.42.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:e4545cf02ec2a4601812f17405b03b7f1f2cf36862cdcf1966065c749db926e0
+      imageId: sha256:459457b70de9b3d7458c8c5066a32972203470d2c6ba5ddce7c3fad06f7b7bc2
       repository: armory/rosco-armory
-      tag: 2022.05.18.18.09.00.release-2.28.x
+      tag: 2022.05.18.20.59.42.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 16feb09310155bd0d18e18033d399d1d64411ef3
+      sha: 07620baf7b0460f0ab42562fc21b847f771c0dcd
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "53c66665ec0efa39fc81795cccdf08a72767ec22"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:459457b70de9b3d7458c8c5066a32972203470d2c6ba5ddce7c3fad06f7b7bc2",
        "repository": "armory/rosco-armory",
        "tag": "2022.05.18.20.59.42.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "07620baf7b0460f0ab42562fc21b847f771c0dcd"
      }
    },
    "name": "rosco-armory"
  }
}
```