### PR TITLE
chore(cd): update kayenta-armory version to 2022.05.18.21.13.15.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:c41ca53a17a963c100ed8cdc5a641d190655e1261f625d9e62ec22054bc54648
+      imageId: sha256:7f9d667e7a353e6406442fdbc6392eebeeb46aa2ee0a8b63f6300810191221e0
       repository: armory/kayenta-armory
-      tag: 2022.05.11.18.01.59.release-2.28.x
+      tag: 2022.05.18.21.13.15.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 098bdb638e825225cd44138e4b9c5fa9e8dbd7c2
+      sha: ebc7a92d06ed18b93233a6c887fe9acfd85ccc8c
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "kayenta",
        "type": "github"
      },
      "sha": "12be87dc853c47d6f91594931d2c1501676aab73"
    },
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:7f9d667e7a353e6406442fdbc6392eebeeb46aa2ee0a8b63f6300810191221e0",
        "repository": "armory/kayenta-armory",
        "tag": "2022.05.18.21.13.15.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "ebc7a92d06ed18b93233a6c887fe9acfd85ccc8c"
      }
    },
    "name": "kayenta-armory"
  }
}
```