### PR TITLE
chore(cd): update rosco-armory version to 2022.05.20.19.37.45.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:449773eb2d71bd91f3c41cf8767eb7cc18bf4382113438d0566ae91c0683177c
+      imageId: sha256:c1c5df9e9d42148cf1c783d74ed5ae8c2a48ac98be043e7e21388d72b7e58234
       repository: armory/rosco-armory
-      tag: 2022.05.18.21.53.35.release-2.28.x
+      tag: 2022.05.20.19.37.45.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 8bf193b7b47ba22d6443336ea45773fa546d66f7
+      sha: 8878e069687bfd229bd00907ede66dfe1b73d2e0
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "53c66665ec0efa39fc81795cccdf08a72767ec22"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:c1c5df9e9d42148cf1c783d74ed5ae8c2a48ac98be043e7e21388d72b7e58234",
        "repository": "armory/rosco-armory",
        "tag": "2022.05.20.19.37.45.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "8878e069687bfd229bd00907ede66dfe1b73d2e0"
      }
    },
    "name": "rosco-armory"
  }
}
```