### PR TITLE
chore(cd): update echo-armory version to 2022.05.20.19.48.50.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:f1c56706c17b3521239424d66aa3e1f6675001373efcc3477429ae2e1dfca123
+      imageId: sha256:002527a18af4db4ab0f69537d4825024fbf494afafb9a541ffd62a784232d744
       repository: armory/echo-armory
-      tag: 2022.05.18.20.57.08.release-2.28.x
+      tag: 2022.05.20.19.48.50.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 07633630b58c15b5145cc00af08528f0b2b0607f
+      sha: 488477dd85edfc6206337bb31f76892e641d1803
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "883deb30c4d2be2b5851ab3a8da60a498cc98079"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:002527a18af4db4ab0f69537d4825024fbf494afafb9a541ffd62a784232d744",
        "repository": "armory/echo-armory",
        "tag": "2022.05.20.19.48.50.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "488477dd85edfc6206337bb31f76892e641d1803"
      }
    },
    "name": "echo-armory"
  }
}
```