### PR TITLE
chore(cd): update fiat-armory version to 2022.05.20.23.15.25.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:d90a0ad93b323721e3a9a3a735675e993fda217e81f38b2af25246d9fb7cbe58
+      imageId: sha256:504cc065491151d15eafadeb4ef9de748065ce5d4f134c54648b64b354faa736
       repository: armory/fiat-armory
-      tag: 2022.05.18.20.56.57.release-2.28.x
+      tag: 2022.05.20.23.15.25.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 6748c08dc6b2329724076684a66b11ae7f3dce76
+      sha: 9aca7990e68cc8022a55af31db7df1d04e02de4c
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "33f8653e7d3bbab4f7385f60ff4de36d880561aa"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:504cc065491151d15eafadeb4ef9de748065ce5d4f134c54648b64b354faa736",
        "repository": "armory/fiat-armory",
        "tag": "2022.05.20.23.15.25.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "9aca7990e68cc8022a55af31db7df1d04e02de4c"
      }
    },
    "name": "fiat-armory"
  }
}
```