### PR TITLE
chore(cd): update front50-armory version to 2022.05.24.09.02.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,17 +62,17 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:57dd33b0f413e1ce258d1ff37f89de9cf775b12facfe818b8d8c4fa557f84ded
+      imageId: sha256:82c575fda70986f533370eb4b2598848adf42aad99bf7158c780c24ddf80365d
       repository: armory/front50-armory
-      tag: 2022.04.01.15.54.53.master
+      tag: 2022.05.24.09.02.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
+      sha: 31aa8ff62d5c883762fe7d910f0416a7c9fe015a
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "a63858a95eca5781ef0317eab7ab81c30a44a694"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:82c575fda70986f533370eb4b2598848adf42aad99bf7158c780c24ddf80365d",
        "repository": "armory/front50-armory",
        "tag": "2022.05.24.09.02.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "31aa8ff62d5c883762fe7d910f0416a7c9fe015a"
      }
    },
    "name": "front50-armory"
  }
}
```