### PR TITLE
chore(cd): update deck-armory version to 2022.05.24.10.12.51.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:84e8ddea1477b943f63d3e4200c225de242e6c9d8c663369d3b022837bb3e70e
+      imageId: sha256:6b3e0447f06eac7d0e35f710b1a7ff3fc580c7301e71bb8514e392e5ab9a2eae
       repository: armory/deck-armory
-      tag: 2022.03.24.09.08.14.release-2.28.x
+      tag: 2022.05.24.10.12.51.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: fc550ba9099e491e50b94de431c5571dfdc6fc7e
+      sha: ac414551dc5044e9d6661827a30885eb9d364468
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "1660a69403841a868100f6859b3fd494ab611f13"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:6b3e0447f06eac7d0e35f710b1a7ff3fc580c7301e71bb8514e392e5ab9a2eae",
        "repository": "armory/deck-armory",
        "tag": "2022.05.24.10.12.51.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "ac414551dc5044e9d6661827a30885eb9d364468"
      }
    },
    "name": "deck-armory"
  }
}
```