### PR TITLE
chore(cd): update gate-armory version to 2022.05.27.15.45.42.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -72,19 +72,19 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
-      imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
+      imageId: sha256:f3a2cd5605caa41921ec804d444c805ca3d7ed711502e455e597fac68a6b2c1f
       repository: armory/gate-armory
-      tag: 2022.04.08.21.04.38.master
+      tag: 2022.05.27.15.45.42.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
+      sha: 71b341d15cfbac58e80271af8a2176087bb4a312
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "98c298f27e4c42fb24c3604c6b74682d8f1e2d6d"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:f3a2cd5605caa41921ec804d444c805ca3d7ed711502e455e597fac68a6b2c1f",
        "repository": "armory/gate-armory",
        "tag": "2022.05.27.15.45.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "71b341d15cfbac58e80271af8a2176087bb4a312"
      }
    },
    "name": "gate-armory"
  }
}
```