### PR TITLE
chore(cd): update terraformer version to 2022.06.02.19.57.57.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:f29497485b0b75cfd22b3658499189dd6076793a06cf65b5b5207c3f8dbfe443
+      imageId: sha256:17779b1a3192359686a8e72cfa6b4b80a5d198d10cebc98e5ba56ef73c2e1d98
       repository: armory/terraformer
-      tag: 2021.12.08.16.32.05.master
+      tag: 2022.06.02.19.57.57.master
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: a9eacb43c1edd0cb2159ec038eecf246d6147f25
+      sha: d6112e34a3433bd8ab6a8735f2d8df165c15be40


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:17779b1a3192359686a8e72cfa6b4b80a5d198d10cebc98e5ba56ef73c2e1d98",
        "repository": "armory/terraformer",
        "tag": "2022.06.02.19.57.57.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d6112e34a3433bd8ab6a8735f2d8df165c15be40"
      }
    },
    "name": "terraformer"
  }
}
```