### PR TITLE
chore(cd): update clouddriver-armory version to 2022.06.03.23.04.44.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:3824f97efe41c575c5fbf3c51fb46d00ff4464c9c8c17005c0d49aaeaa977e65
+      imageId: sha256:53f4a4fdde6580a7b46f335f9591e9c0e8199f9278e79ca2f1f5688d500d1117
       repository: armory/clouddriver-armory
-      tag: 2022.05.18.20.55.16.release-2.28.x
+      tag: 2022.06.03.23.04.44.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 473f34b0c776ff56e443c1db4244f2aa9257aa91
+      sha: 188d76cfbc65dd5da1d7de9e7813a8d107945066
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "1cf66a05e1064ca6e3970a22dd8ee35698028449"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:53f4a4fdde6580a7b46f335f9591e9c0e8199f9278e79ca2f1f5688d500d1117",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.06.03.23.04.44.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "188d76cfbc65dd5da1d7de9e7813a8d107945066"
      }
    },
    "name": "clouddriver-armory"
  }
}
```