### PR TITLE
chore(cd): update rosco-armory version to 2022.06.06.17.25.00.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:caae7d39ce4f36e6f4c3f806e55ba46755801490186fdc493526e3eb46c7833b
+      imageId: sha256:8ef35542375d21f23b3e7059352c2dd27f601f56eb8a7fc8a7d3a407065ab84f
       repository: armory/rosco-armory
-      tag: 2022.04.01.15.50.46.master
+      tag: 2022.06.06.17.25.00.master
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 06f25d3966952226e8ec90084bc29da3602602d9
+      sha: 22c4776c587bca58632dda16ee0cedf7605f1605
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "f6d302e24d2f9158c5aa8366e934686b07bb73ec"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:8ef35542375d21f23b3e7059352c2dd27f601f56eb8a7fc8a7d3a407065ab84f",
        "repository": "armory/rosco-armory",
        "tag": "2022.06.06.17.25.00.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "22c4776c587bca58632dda16ee0cedf7605f1605"
      }
    },
    "name": "rosco-armory"
  }
}
```