### PR TITLE
chore(cd): update deck-armory version to 2022.06.06.18.17.57.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:6b3e0447f06eac7d0e35f710b1a7ff3fc580c7301e71bb8514e392e5ab9a2eae
+      imageId: sha256:c82738a5e6ceb9e305127ad785b16028fcd3a47ba93fe1933e94cea1fd4ddb40
       repository: armory/deck-armory
-      tag: 2022.05.24.10.12.51.release-2.28.x
+      tag: 2022.06.06.18.17.57.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: ac414551dc5044e9d6661827a30885eb9d364468
+      sha: fb3d82a10893e234e2988450e28d53924a4bb2a3
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "349cd1c3a3b0797285bc28ac41787d650e10c478"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:c82738a5e6ceb9e305127ad785b16028fcd3a47ba93fe1933e94cea1fd4ddb40",
        "repository": "armory/deck-armory",
        "tag": "2022.06.06.18.17.57.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "fb3d82a10893e234e2988450e28d53924a4bb2a3"
      }
    },
    "name": "deck-armory"
  }
}
```