### PR TITLE
chore(cd): update gate-armory version to 2022.06.07.15.27.43.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:c69f270836c0ee9b82f4f7444bfdde25856e3ee890dc20b8f6b3be9f41ad16aa
+      imageId: sha256:a3068434b5efe7d3b6faf69d2be054dcb71a444711f1cbcb64409b8403fdb5a1
       repository: armory/gate-armory
-      tag: 2022.05.18.20.57.43.release-2.28.x
+      tag: 2022.06.07.15.27.43.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: d0761570b845d9dbda0f117ff6f56d78ac203cfb
+      sha: 0e15acb4f229f88830bd7b2afbd9d9fe249e6502
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "115805786e5e30ec591b077ebad91c2658c4cbf2"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:a3068434b5efe7d3b6faf69d2be054dcb71a444711f1cbcb64409b8403fdb5a1",
        "repository": "armory/gate-armory",
        "tag": "2022.06.07.15.27.43.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "0e15acb4f229f88830bd7b2afbd9d9fe249e6502"
      }
    },
    "name": "gate-armory"
  }
}
```