### PR TITLE
chore(cd): update terraformer version to 2022.06.07.19.26.36.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:02297526ca9dba9c60a7a4ca7f5384811e916f31bd2f0b72fdd239da760f8183
+      imageId: sha256:dc775734fc49b81cd036a080b074b6d16c6c4224cce089dc089a0e63b50a3c54
       repository: armory/terraformer
-      tag: 2022.06.07.18.44.09.release-2.28.x
+      tag: 2022.06.07.19.26.36.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 242708d1942db1329a3c688c91def8c4caef763d
+      sha: d48f30874895dae37f214e4b4a8900cb44c721e0


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:dc775734fc49b81cd036a080b074b6d16c6c4224cce089dc089a0e63b50a3c54",
        "repository": "armory/terraformer",
        "tag": "2022.06.07.19.26.36.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d48f30874895dae37f214e4b4a8900cb44c721e0"
      }
    },
    "name": "terraformer"
  }
}
```