### PR TITLE
chore(cd): update terraformer version to 2022.06.07.19.52.50.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:dc775734fc49b81cd036a080b074b6d16c6c4224cce089dc089a0e63b50a3c54
+      imageId: sha256:7d2f0a7a05cdbd145719f41a5378aaafddf06c63878cd90a679ebdbb68eda39b
       repository: armory/terraformer
-      tag: 2022.06.07.19.26.36.release-2.28.x
+      tag: 2022.06.07.19.52.50.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: d48f30874895dae37f214e4b4a8900cb44c721e0
+      sha: 53dad94ee5b0c786a727bd6f9524739cf59fc4c9


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:7d2f0a7a05cdbd145719f41a5378aaafddf06c63878cd90a679ebdbb68eda39b",
        "repository": "armory/terraformer",
        "tag": "2022.06.07.19.52.50.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "53dad94ee5b0c786a727bd6f9524739cf59fc4c9"
      }
    },
    "name": "terraformer"
  }
}
```