### PR TITLE
chore(cd): update deck-armory version to 2022.06.08.17.10.52.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:c82738a5e6ceb9e305127ad785b16028fcd3a47ba93fe1933e94cea1fd4ddb40
+      imageId: sha256:c9450caaf4c134ebab3548f03a40e275a8879c33f153fde4c2d193a05cda253d
       repository: armory/deck-armory
-      tag: 2022.06.06.18.17.57.release-2.28.x
+      tag: 2022.06.08.17.10.52.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: fb3d82a10893e234e2988450e28d53924a4bb2a3
+      sha: 693348595c771625ac4bdc5224921b5882578d79
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "349cd1c3a3b0797285bc28ac41787d650e10c478"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:c9450caaf4c134ebab3548f03a40e275a8879c33f153fde4c2d193a05cda253d",
        "repository": "armory/deck-armory",
        "tag": "2022.06.08.17.10.52.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "693348595c771625ac4bdc5224921b5882578d79"
      }
    },
    "name": "deck-armory"
  }
}
```