### PR TITLE
chore(cd): update terraformer version to 2022.06.08.17.56.10.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: null
     image:
-      imageId: sha256:f3dfa4d12130f0444cabe110e5c865384f4dc4937ea108a532db7ed53fc03fb2
+      imageId: sha256:27e5c5a4fa7e8d0e7595dd2a157578ef97f535c826d767033fa44f99ef29878d
       repository: armory/terraformer
-      tag: 2022.06.08.17.19.37.release-2.28.x
+      tag: 2022.06.08.17.56.10.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: cc5d52a61e95aa2f8eef88915f5aec8d6d6ac001
+      sha: c3c07a7c4f09752409183f906fb9fa5458e7d602


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": null,
      "image": {
        "imageId": "sha256:27e5c5a4fa7e8d0e7595dd2a157578ef97f535c826d767033fa44f99ef29878d",
        "repository": "armory/terraformer",
        "tag": "2022.06.08.17.56.10.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "c3c07a7c4f09752409183f906fb9fa5458e7d602"
      }
    },
    "name": "terraformer"
  }
}
```