### PR TITLE
chore(cd): update deck-armory version to 2022.06.14.17.39.13.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:576c9881b273fdddb0d5b6a7c0e2acdfe9c71c66ddc5ac622d4f692f976e165a
+      imageId: sha256:25ba3c90c190127021b273c73ccc8373b7663f354d99326858148fb3b7fb4fd6
       repository: armory/deck-armory
-      tag: 2022.04.27.04.22.58.release-2.27.x
+      tag: 2022.06.14.17.39.13.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: cc69c0b320aefa63215703df4f4801acabbb1d53
+      sha: aff6b09daf760af3f86bc194cb0945c44fcd5b4f
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "9f6b4dce228d35d0a54d56d79c17424eec04704b"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:25ba3c90c190127021b273c73ccc8373b7663f354d99326858148fb3b7fb4fd6",
        "repository": "armory/deck-armory",
        "tag": "2022.06.14.17.39.13.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "aff6b09daf760af3f86bc194cb0945c44fcd5b4f"
      }
    },
    "name": "deck-armory"
  }
}
```