### PR TITLE
chore(cd): update deck-armory version to 2022.06.14.17.54.03.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:25ba3c90c190127021b273c73ccc8373b7663f354d99326858148fb3b7fb4fd6
+      imageId: sha256:2da0eb2b853470eba9e5e49b09be96835406411d1ecfddc585930b6951480648
       repository: armory/deck-armory
-      tag: 2022.06.14.17.39.13.release-2.27.x
+      tag: 2022.06.14.17.54.03.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: aff6b09daf760af3f86bc194cb0945c44fcd5b4f
+      sha: d0a4c0b534877e8b38d9dc03c2dc4a683c289a64
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "0417e97fb2baea07bdff3acf3b40aa2008a9c30f"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2da0eb2b853470eba9e5e49b09be96835406411d1ecfddc585930b6951480648",
        "repository": "armory/deck-armory",
        "tag": "2022.06.14.17.54.03.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "d0a4c0b534877e8b38d9dc03c2dc4a683c289a64"
      }
    },
    "name": "deck-armory"
  }
}
```