### PR TITLE
chore(cd): update clouddriver-armory version to 2022.06.14.19.47.58.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:53f4a4fdde6580a7b46f335f9591e9c0e8199f9278e79ca2f1f5688d500d1117
+      imageId: sha256:0c331ed36bb94b1ea92960e391d8a8555b400eafba1dbfebbd2abb5fc3fcc5e3
       repository: armory/clouddriver-armory
-      tag: 2022.06.03.23.04.44.release-2.28.x
+      tag: 2022.06.14.19.47.58.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 188d76cfbc65dd5da1d7de9e7813a8d107945066
+      sha: e8c9c4ef055315d1271e1805241c08fbe2629725
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "2cbecd73b1e214f7738e0251d191b30a9588f7ea"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0c331ed36bb94b1ea92960e391d8a8555b400eafba1dbfebbd2abb5fc3fcc5e3",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.06.14.19.47.58.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "e8c9c4ef055315d1271e1805241c08fbe2629725"
      }
    },
    "name": "clouddriver-armory"
  }
}
```