### PR TITLE
chore(cd): update gate-armory version to 2022.06.15.17.51.55.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:b261a74930318b96b93ab4e46061bc1384166355f9376a9209d46eee23fac5fe
+      imageId: sha256:54775b7dc6bb484dd6dc127b2b65a2024737b81b9ee8d5512aaabc8d9b780a98
       repository: armory/gate-armory
-      tag: 2022.04.27.05.44.01.release-2.27.x
+      tag: 2022.06.15.17.51.55.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 2d66cb9252236e6f9ebc8c486c038b0b01dcaa60
+      sha: 3575251530883797df41742f766b467611645159
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "c2972d12c297263391ca917fde5b5b9c1452e382"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:54775b7dc6bb484dd6dc127b2b65a2024737b81b9ee8d5512aaabc8d9b780a98",
        "repository": "armory/gate-armory",
        "tag": "2022.06.15.17.51.55.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "3575251530883797df41742f766b467611645159"
      }
    },
    "name": "gate-armory"
  }
}
```