### PR TITLE
chore(cd): update clouddriver-armory version to 2022.07.06.00.14.57.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:0c331ed36bb94b1ea92960e391d8a8555b400eafba1dbfebbd2abb5fc3fcc5e3
+      imageId: sha256:57cf00ab2b29bc9547467a2e62caf16fa2be0f48ae914ca3fe2432a3b292eddf
       repository: armory/clouddriver-armory
-      tag: 2022.06.14.19.47.58.release-2.28.x
+      tag: 2022.07.06.00.14.57.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: e8c9c4ef055315d1271e1805241c08fbe2629725
+      sha: 4bdd7850e874672bdc1f8cc360c08b7e9497b4ff
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "b1a4dda2428f779564fdd4de1bdcbe226a736c80"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:57cf00ab2b29bc9547467a2e62caf16fa2be0f48ae914ca3fe2432a3b292eddf",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.07.06.00.14.57.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "4bdd7850e874672bdc1f8cc360c08b7e9497b4ff"
      }
    },
    "name": "clouddriver-armory"
  }
}
```