### PR TITLE
chore(cd): update deck-armory version to 2022.07.07.00.07.26.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:c3172fc5afd668d03bd95d206162001366c8672178afdff3f929a34d554d80f0
+      imageId: sha256:020777d72afd3240c7b01e71ae1c9202742ffb38c83d1f14402c731ea3527965
       repository: armory/deck-armory
-      tag: 2022.07.05.21.12.24.release-2.28.x
+      tag: 2022.07.07.00.07.26.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 9b0cf4b69531092914811f5ded0cf34aefa8c5d6
+      sha: cba7fd84457fd2dc97fe10ac62acd6c467a88031
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "364bc4d64e87cc2494839632a0ddcfd98ae89da1"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:020777d72afd3240c7b01e71ae1c9202742ffb38c83d1f14402c731ea3527965",
        "repository": "armory/deck-armory",
        "tag": "2022.07.07.00.07.26.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "cba7fd84457fd2dc97fe10ac62acd6c467a88031"
      }
    },
    "name": "deck-armory"
  }
}
```