### PR TITLE
chore(cd): update igor-armory version to 2022.07.08.15.30.30.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:2fc96f2860dde819bf15930e81795b8b298e50d86470bd05ea5da9ed6bec0afa
+      imageId: sha256:f7f9bcf2e49a4c962db1c915ead704498f302e3e6cdd10dcd823eb45fae3f075
       repository: armory/igor-armory
-      tag: 2022.04.27.05.45.17.release-2.27.x
+      tag: 2022.07.08.15.30.30.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: efc2244af80153e2e8c7cf30ad0da95d3c0e00b7
+      sha: e9399998f26517271acda3c083a6c4c0f2d38fa2
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:f7f9bcf2e49a4c962db1c915ead704498f302e3e6cdd10dcd823eb45fae3f075",
        "repository": "armory/igor-armory",
        "tag": "2022.07.08.15.30.30.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "e9399998f26517271acda3c083a6c4c0f2d38fa2"
      }
    },
    "name": "igor-armory"
  }
}
```