### PR TITLE
chore(cd): update kayenta-armory version to 2022.07.08.15.31.25.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:7f9d667e7a353e6406442fdbc6392eebeeb46aa2ee0a8b63f6300810191221e0
+      imageId: sha256:1e6b941de1998cf0d3770c6bebbda7f3892eea3361a1477fc8840b7a737526b1
       repository: armory/kayenta-armory
-      tag: 2022.05.18.21.13.15.release-2.28.x
+      tag: 2022.07.08.15.31.25.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: ebc7a92d06ed18b93233a6c887fe9acfd85ccc8c
+      sha: 7bfe2c300432c865f10f07985d81decb58b1ee48
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:1e6b941de1998cf0d3770c6bebbda7f3892eea3361a1477fc8840b7a737526b1",
        "repository": "armory/kayenta-armory",
        "tag": "2022.07.08.15.31.25.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "7bfe2c300432c865f10f07985d81decb58b1ee48"
      }
    },
    "name": "kayenta-armory"
  }
}
```