### PR TITLE
chore(cd): update kayenta-armory version to 2022.07.08.15.31.16.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:ac4bd8d2bf6e9d2c4612a8bc7131a66ffb5e0699ea3836aecaddb25d41aa1e40
+      imageId: sha256:41fd13c65e6f31cd68671852a620d69ed3559daad78280b2428c9cdb180cf591
       repository: armory/kayenta-armory
-      tag: 2022.05.06.00.09.19.release-2.27.x
+      tag: 2022.07.08.15.31.16.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 1e2237a01de8216325d86bb2fcdb869ab15be5d2
+      sha: 62cb8fcdb89b30da5c9060bda912d40ca56a167f
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:41fd13c65e6f31cd68671852a620d69ed3559daad78280b2428c9cdb180cf591",
        "repository": "armory/kayenta-armory",
        "tag": "2022.07.08.15.31.16.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "62cb8fcdb89b30da5c9060bda912d40ca56a167f"
      }
    },
    "name": "kayenta-armory"
  }
}
```