### PR TITLE
chore(cd): update igor-armory version to 2022.07.08.15.30.35.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -86,15 +86,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:9a31a3dfd2558416a41cb0959240f53c1e0b150ee125713613e004157fd97457
+      imageId: sha256:f91b908d10ba1d10387b63b2d97bf49fb55a7615a3785551cbfd97da5d1141f9
       repository: armory/igor-armory
-      tag: 2022.05.18.20.57.02.release-2.28.x
+      tag: 2022.07.08.15.30.35.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: 5ea6da54f840ecaffa72d62386d9efd7bb54e0fe
+      sha: c10937f0110f81bd2f17dfea79bfbf01f53598a5
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:f91b908d10ba1d10387b63b2d97bf49fb55a7615a3785551cbfd97da5d1141f9",
        "repository": "armory/igor-armory",
        "tag": "2022.07.08.15.30.35.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "c10937f0110f81bd2f17dfea79bfbf01f53598a5"
      }
    },
    "name": "igor-armory"
  }
}
```