### PR TITLE
chore(cd): update orca-armory version to 2022.07.08.15.35.58.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:2b83a64577896371246ce68c97323c8c3f632b4bda0f66112383bc11c8b86acb
+      imageId: sha256:94899b60fe01a6ca384f95ea8e4640dc71ff572c5165cbe5f3ac635c8e600a38
       repository: armory/orca-armory
-      tag: 2022.05.18.20.57.13.release-2.28.x
+      tag: 2022.07.08.15.35.58.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 877733807a0661adef388e9ad45f79506428e2fe
+      sha: 30ca83945081107105b9186461730988fabd11d5
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "337c568ebb361352eac99fa163657cc4574ea372"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:94899b60fe01a6ca384f95ea8e4640dc71ff572c5165cbe5f3ac635c8e600a38",
        "repository": "armory/orca-armory",
        "tag": "2022.07.08.15.35.58.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "30ca83945081107105b9186461730988fabd11d5"
      }
    },
    "name": "orca-armory"
  }
}
```