### PR TITLE
chore(cd): update fiat-armory version to 2022.07.08.15.33.02.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:504cc065491151d15eafadeb4ef9de748065ce5d4f134c54648b64b354faa736
+      imageId: sha256:ded31e120790faed02bb06119dd6277b3200733af98643f38128526a0c271cd4
       repository: armory/fiat-armory
-      tag: 2022.05.20.23.15.25.release-2.28.x
+      tag: 2022.07.08.15.33.02.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: fiat-armory
         type: github
-      sha: 9aca7990e68cc8022a55af31db7df1d04e02de4c
+      sha: 5728f3484b01459e9b246117cdfbb54f9d00768c
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "fiat",
        "type": "github"
      },
      "sha": "33f8653e7d3bbab4f7385f60ff4de36d880561aa"
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:ded31e120790faed02bb06119dd6277b3200733af98643f38128526a0c271cd4",
        "repository": "armory/fiat-armory",
        "tag": "2022.07.08.15.33.02.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "fiat-armory",
          "type": "github"
        },
        "sha": "5728f3484b01459e9b246117cdfbb54f9d00768c"
      }
    },
    "name": "fiat-armory"
  }
}
```