### PR TITLE
chore(cd): update rosco-armory version to 2022.07.11.18.13.11.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:c1c5df9e9d42148cf1c783d74ed5ae8c2a48ac98be043e7e21388d72b7e58234
+      imageId: sha256:178153ee1683abd7f5feef8ee0fdd24b9cea91ab5dad104f2da604befd428b37
       repository: armory/rosco-armory
-      tag: 2022.05.20.19.37.45.release-2.28.x
+      tag: 2022.07.11.18.13.11.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 8878e069687bfd229bd00907ede66dfe1b73d2e0
+      sha: 36a55d07da5f25fc385e67922e35f387f13a6fb1
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "53c66665ec0efa39fc81795cccdf08a72767ec22"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:178153ee1683abd7f5feef8ee0fdd24b9cea91ab5dad104f2da604befd428b37",
        "repository": "armory/rosco-armory",
        "tag": "2022.07.11.18.13.11.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "36a55d07da5f25fc385e67922e35f387f13a6fb1"
      }
    },
    "name": "rosco-armory"
  }
}
```