### PR TITLE
chore(cd): update deck-armory version to 2022.07.13.16.18.30.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:020777d72afd3240c7b01e71ae1c9202742ffb38c83d1f14402c731ea3527965
+      imageId: sha256:8ee64addc90e2dc122404ee059abc6ecacd8be9998ffa364249aaf1eff3b847c
       repository: armory/deck-armory
-      tag: 2022.07.07.00.07.26.release-2.28.x
+      tag: 2022.07.13.16.18.30.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: cba7fd84457fd2dc97fe10ac62acd6c467a88031
+      sha: 8a74fc9b4209e75de313230e9e2129a80f357d0e
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "0693425345b689d495c9dc1c0f35dd585d5d96db"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:8ee64addc90e2dc122404ee059abc6ecacd8be9998ffa364249aaf1eff3b847c",
        "repository": "armory/deck-armory",
        "tag": "2022.07.13.16.18.30.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "8a74fc9b4209e75de313230e9e2129a80f357d0e"
      }
    },
    "name": "deck-armory"
  }
}
```