### PR TITLE
chore(cd): update deck-armory version to 2022.07.14.13.56.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:e420cf59df863af3d9a213e958ddaa1d97c42b76235f01fa6641f859b51a9a81
+      imageId: sha256:2f94ffeed22b021388f25937b4a6b469d82fa0081c1bc8a41876e6ec2cfa85b9
       repository: armory/deck-armory
-      tag: 2022.03.24.09.08.14.master
+      tag: 2022.07.14.13.56.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: fc550ba9099e491e50b94de431c5571dfdc6fc7e
+      sha: ae11b1c89c26e50faab501775e4ebbbbe575d755
   dinghy:
     baseService: null
     image:
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,7 +84,7 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
       imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
       repository: armory/igor-armory
@@ -96,7 +96,7 @@ services:
         type: github
       sha: abeae9a43af57715379281715fc6f82e282c28a2
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "1c7614c9479f089d966378e4f1ae9c7aa14502bf"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2f94ffeed22b021388f25937b4a6b469d82fa0081c1bc8a41876e6ec2cfa85b9",
        "repository": "armory/deck-armory",
        "tag": "2022.07.14.13.56.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "ae11b1c89c26e50faab501775e4ebbbbe575d755"
      }
    },
    "name": "deck-armory"
  }
}
```