### PR TITLE
chore(cd): update deck-armory version to 2022.07.14.16.52.46.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:12f97ec90567d9c8445d43a28d6aee5942a5d505a5d8bb5536792a45739ae906
+      imageId: sha256:ebb903df95007596fa4d7bba2b5faf7c057739eb627fec798ffd381359265f4c
       repository: armory/deck-armory
-      tag: 2022.07.14.16.02.56.release-2.28.x
+      tag: 2022.07.14.16.52.46.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: bf0e14141fa6b002d661e1d747f0ccc7f3992655
+      sha: 108847b83576abf24d437a0c89015a65f337ec54
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "8cc829378c0132ce42381d8769ca2f2df0316ca1"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:ebb903df95007596fa4d7bba2b5faf7c057739eb627fec798ffd381359265f4c",
        "repository": "armory/deck-armory",
        "tag": "2022.07.14.16.52.46.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "108847b83576abf24d437a0c89015a65f337ec54"
      }
    },
    "name": "deck-armory"
  }
}
```