### PR TITLE
chore(cd): update igor-armory version to 2022.07.28.00.02.09.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -72,7 +72,7 @@ services:
         type: github
       sha: 343e10bdf12d6e5d2718cda1f265e0a8429353ed
   gate-armory:
-    baseService: gate 
+    baseService: gate
     image:
       imageId: sha256:04e4b4eee935e4e3469bcfe1b657af65502ed430709525c81720855e31a9a12c
       repository: armory/gate-armory
@@ -84,19 +84,19 @@ services:
         type: github
       sha: 35dfbcbd6f59ac83b744bbeb98d4666cbfb86447
   igor-armory:
-    baseService: igor 
+    baseService: igor
     image:
-      imageId: sha256:0ed9d8119ff680a6c71702ccd1b5a03c209457d3ec72f8e0d48ecb0fa2032a0d
+      imageId: sha256:4fd5c549f29fc390cccabd82a9ce31516ddb1f2033d7aa7d52eb26f37a88f260
       repository: armory/igor-armory
-      tag: 2022.04.08.20.51.51.master
+      tag: 2022.07.28.00.02.09.master
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: abeae9a43af57715379281715fc6f82e282c28a2
+      sha: a14ea9314e1bf95599f32f881825f04487b42164
   kayenta-armory:
-    baseService: kayenta 
+    baseService: kayenta
     image:
       imageId: sha256:14f773db08dfe67cd0d1b7aadcc2aea3a77ae810ec3d74189a4cff453c909fa1
       repository: armory/kayenta-armory


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "31b05526ce1ac46151c21f6a7d381c68baff5767"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:4fd5c549f29fc390cccabd82a9ce31516ddb1f2033d7aa7d52eb26f37a88f260",
        "repository": "armory/igor-armory",
        "tag": "2022.07.28.00.02.09.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "a14ea9314e1bf95599f32f881825f04487b42164"
      }
    },
    "name": "igor-armory"
  }
}
```