### PR TITLE
chore(cd): update orca-armory version to 2022.08.03.03.33.08.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:94899b60fe01a6ca384f95ea8e4640dc71ff572c5165cbe5f3ac635c8e600a38
+      imageId: sha256:125b613e181e4957838ad70d42cece7362e95c8190a62be3bd082ce16859a245
       repository: armory/orca-armory
-      tag: 2022.07.08.15.35.58.release-2.28.x
+      tag: 2022.08.03.03.33.08.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 30ca83945081107105b9186461730988fabd11d5
+      sha: 0f84f60ad447a5cbdf019b40aaa9b10111fa8f73
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:125b613e181e4957838ad70d42cece7362e95c8190a62be3bd082ce16859a245",
        "repository": "armory/orca-armory",
        "tag": "2022.08.03.03.33.08.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "0f84f60ad447a5cbdf019b40aaa9b10111fa8f73"
      }
    },
    "name": "orca-armory"
  }
}
```