### PR TITLE
chore(cd): update front50-armory version to 2022.08.03.21.55.44.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:cf0a5679493ca4b9cf04fecba4ae1e6689aa6ae827593d2684d34c62b468aa1f
+      imageId: sha256:6ec709750d205935f2a93e73cc1b7b4cc4fbe41cf3fc36ee1b640dc93fd7cd54
       repository: armory/front50-armory
-      tag: 2022.07.08.15.30.43.release-2.28.x
+      tag: 2022.08.03.21.55.44.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 1bc61a77916acf5bf7b13041005e730bdac8cd8e
+      sha: 2347a0cc42dfd1341159290557a2355e63e20962
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "8215d49ee57686aa9c2dbc5b3ebd06fd1b985dd6"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:6ec709750d205935f2a93e73cc1b7b4cc4fbe41cf3fc36ee1b640dc93fd7cd54",
        "repository": "armory/front50-armory",
        "tag": "2022.08.03.21.55.44.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "2347a0cc42dfd1341159290557a2355e63e20962"
      }
    },
    "name": "front50-armory"
  }
}
```