### PR TITLE
chore(cd): update rosco-armory version to 2022.08.11.01.05.03.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:178153ee1683abd7f5feef8ee0fdd24b9cea91ab5dad104f2da604befd428b37
+      imageId: sha256:a7b845c247d6bf1ddf0249a31af688f5a0b7f87b2e13a41659d6992060ff0a4a
       repository: armory/rosco-armory
-      tag: 2022.07.11.18.13.11.release-2.28.x
+      tag: 2022.08.11.01.05.03.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: rosco-armory
         type: github
-      sha: 36a55d07da5f25fc385e67922e35f387f13a6fb1
+      sha: 77806ba40e2e0031d6c76e28fc09c2c3511e9731
   terraformer:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "rosco",
        "type": "github"
      },
      "sha": "06b2900e558b08247fee0854d391f3a8635da0ed"
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:a7b845c247d6bf1ddf0249a31af688f5a0b7f87b2e13a41659d6992060ff0a4a",
        "repository": "armory/rosco-armory",
        "tag": "2022.08.11.01.05.03.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "rosco-armory",
          "type": "github"
        },
        "sha": "77806ba40e2e0031d6c76e28fc09c2c3511e9731"
      }
    },
    "name": "rosco-armory"
  }
}
```