### PR TITLE
chore(cd): update orca-armory version to 2022.08.15.20.10.11.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:f214e2e9d90b3a44c6d07117293f97c093ac9d9026d526bd5ccff3215874cd7a
+      imageId: sha256:a075b798ab324ad7697db821194821f2a031f8f315b88a2094a68e415c082e00
       repository: armory/orca-armory
-      tag: 2022.07.11.16.21.57.release-2.26.x
+      tag: 2022.08.15.20.10.11.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 8d2b95a66b967de63d90272ae30dd1c8621692cb
+      sha: 92b807ac3b5dde029d70bb960a14da3238abc825
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:a075b798ab324ad7697db821194821f2a031f8f315b88a2094a68e415c082e00",
        "repository": "armory/orca-armory",
        "tag": "2022.08.15.20.10.11.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "92b807ac3b5dde029d70bb960a14da3238abc825"
      }
    },
    "name": "orca-armory"
  }
}
```