### PR TITLE
chore(cd): update kayenta-armory version to 2022.08.15.22.20.47.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -98,15 +98,15 @@ services:
   kayenta-armory:
     baseService: kayenta
     image:
-      imageId: sha256:bd361819cc9abe388ed5fa926408510a4bc0abd8bf578d826b3aec367164cbb3
+      imageId: sha256:7413545b569223bc4e8e13e63b65efc354923a48896ab0b57ffc09cecf9a0853
       repository: armory/kayenta-armory
-      tag: 2022.08.03.03.39.15.release-2.27.x
+      tag: 2022.08.15.22.20.47.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: kayenta-armory
         type: github
-      sha: 68d13f9cb6328e49dc3745bc0ab8a3b2c6f8d969
+      sha: 5b62b61c428ad766e9d54090f4c3fe4ad8ed9461
   orca-armory:
     baseService: orca
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "kayenta",
      "image": {
        "imageId": "sha256:7413545b569223bc4e8e13e63b65efc354923a48896ab0b57ffc09cecf9a0853",
        "repository": "armory/kayenta-armory",
        "tag": "2022.08.15.22.20.47.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "kayenta-armory",
          "type": "github"
        },
        "sha": "5b62b61c428ad766e9d54090f4c3fe4ad8ed9461"
      }
    },
    "name": "kayenta-armory"
  }
}
```