### PR TITLE
chore(cd): update orca-armory version to 2022.08.17.22.52.51.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:aa5988573d82436c8e121941e396a132df7c286d94755f50b9f1249ad3c87913
+      imageId: sha256:7d1943ed736f7163eec56d29c753c9b24563358d7114af1b0ddf556c5452dd93
       repository: armory/orca-armory
-      tag: 2022.08.08.18.20.31.release-2.27.x
+      tag: 2022.08.17.22.52.51.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 417ac6a01e5dcd1e1343ae0b24606089bcecd035
+      sha: a6c3d37a01c2d2cfefa29946747656861e381018
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "728f29cb10e02e4989b49ba6f1d69ab9b8f1ccce"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:7d1943ed736f7163eec56d29c753c9b24563358d7114af1b0ddf556c5452dd93",
        "repository": "armory/orca-armory",
        "tag": "2022.08.17.22.52.51.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "a6c3d37a01c2d2cfefa29946747656861e381018"
      }
    },
    "name": "orca-armory"
  }
}
```