### PR TITLE
chore(cd): update echo-armory version to 2022.08.19.03.35.52.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:056b1a454922a8395d882e6e330304e9f132fb85a230fb7a7607dae72c41608a
+      imageId: sha256:7cdcf3d9c131107872f0176ecc7d82014323a32b1194c2d04fff13eb26f26db3
       repository: armory/echo-armory
-      tag: 2022.08.03.03.22.30.release-2.28.x
+      tag: 2022.08.19.03.35.52.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: 60203d09e2f59ee71679fef98b8acf802d3ef0e9
+      sha: 508646c02d5053c63ca7892b613398cc012ba324
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "cf6fe498b64c18bf2bed803aa3d59d8d3aee12ec"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:7cdcf3d9c131107872f0176ecc7d82014323a32b1194c2d04fff13eb26f26db3",
        "repository": "armory/echo-armory",
        "tag": "2022.08.19.03.35.52.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "508646c02d5053c63ca7892b613398cc012ba324"
      }
    },
    "name": "echo-armory"
  }
}
```