### PR TITLE
chore(cd): update gate-armory version to 2022.08.19.03.36.22.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:d3012d4c5901110f74c95358bf89bc6c95eb05de07c30c79f6bf976d66722a3b
+      imageId: sha256:262a163e44e595b2bd41593912df361cf31f7061d0002059f5f5794621ca7a77
       repository: armory/gate-armory
-      tag: 2022.08.03.03.23.19.release-2.28.x
+      tag: 2022.08.19.03.36.22.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 336ada6c91041875a48043f92d2a85f2c0130532
+      sha: 2b2b668ac5d4cbf126190baf450116de6aa0aa4a
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "4ef0ac247f91c9f7bb2422cd0d909a2f621051d0"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:262a163e44e595b2bd41593912df361cf31f7061d0002059f5f5794621ca7a77",
        "repository": "armory/gate-armory",
        "tag": "2022.08.19.03.36.22.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "2b2b668ac5d4cbf126190baf450116de6aa0aa4a"
      }
    },
    "name": "gate-armory"
  }
}
```