### PR TITLE
chore(cd): update clouddriver-armory version to 2022.08.19.03.45.39.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:c8e003019d8d23bba6a7ce6d39de21d648c08e4b6a384132705e1c9cee44dd83
+      imageId: sha256:078d10efee216c63be9aecd102317cf114babe087cec14725e6deebaff064eec
       repository: armory/clouddriver-armory
-      tag: 2022.08.03.03.46.46.release-2.28.x
+      tag: 2022.08.19.03.45.39.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 2e71ad5ac97015c41648a1446b452a61134543b5
+      sha: 3b1c90e3afdb77f6a3b9b607f6f98d69cb8894a0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "178ccdb149c78bc4eb4ef6d6cdcfe54892f90851"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:078d10efee216c63be9aecd102317cf114babe087cec14725e6deebaff064eec",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.08.19.03.45.39.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3b1c90e3afdb77f6a3b9b607f6f98d69cb8894a0"
      }
    },
    "name": "clouddriver-armory"
  }
}
```