### PR TITLE
chore(cd): update front50-armory version to 2022.08.19.03.39.07.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:6ec709750d205935f2a93e73cc1b7b4cc4fbe41cf3fc36ee1b640dc93fd7cd54
+      imageId: sha256:9c6f675dd1552e6ac8fcf7882146cf0ed937979f6dac35fe34ba131811d37de1
       repository: armory/front50-armory
-      tag: 2022.08.03.21.55.44.release-2.28.x
+      tag: 2022.08.19.03.39.07.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 2347a0cc42dfd1341159290557a2355e63e20962
+      sha: fafda40bcfc87e897fcb4e83b3e0ad131be5ecc7
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "f1b5baecc46715e1d9dacea3c980b8a5229590f0"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:9c6f675dd1552e6ac8fcf7882146cf0ed937979f6dac35fe34ba131811d37de1",
        "repository": "armory/front50-armory",
        "tag": "2022.08.19.03.39.07.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "fafda40bcfc87e897fcb4e83b3e0ad131be5ecc7"
      }
    },
    "name": "front50-armory"
  }
}
```