### PR TITLE
chore(cd): update orca-armory version to 2022.08.19.17.20.20.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:aa5988573d82436c8e121941e396a132df7c286d94755f50b9f1249ad3c87913
+      imageId: sha256:822ac3d49b9ba3eebbdf4361d33159de06c43ca9452577dd5a7be6e1f2ac9deb
       repository: armory/orca-armory
-      tag: 2022.08.08.18.20.31.release-2.27.x
+      tag: 2022.08.19.17.20.20.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 417ac6a01e5dcd1e1343ae0b24606089bcecd035
+      sha: fc9593f3c4da98fa8c7f6753598a75f4ea19a49c
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "0c195d77cac68b70f4559b63f87d573279a0e79f"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:822ac3d49b9ba3eebbdf4361d33159de06c43ca9452577dd5a7be6e1f2ac9deb",
        "repository": "armory/orca-armory",
        "tag": "2022.08.19.17.20.20.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "fc9593f3c4da98fa8c7f6753598a75f4ea19a49c"
      }
    },
    "name": "orca-armory"
  }
}
```