### PR TITLE
chore(cd): update orca-armory version to 2022.08.31.18.41.10.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:a07f498bda756da05e413592a551fe9fb3cba8c6ef17c2c7520636cfe1f6a586
+      imageId: sha256:ae07005ef19349c7a3e5ef070f04ab69ae3f9ddfb708152cfd822288277762a0
       repository: armory/orca-armory
-      tag: 2022.04.04.16.22.09.master
+      tag: 2022.08.31.18.41.10.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 238fc61ed93dd33702377f756455b44fff5acb5d
+      sha: 8a4ec7e9ffae1760addff03861b488ede6a7458b
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "bc97a24a637cb59843db3a60cfeec4465d10f703"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:ae07005ef19349c7a3e5ef070f04ab69ae3f9ddfb708152cfd822288277762a0",
        "repository": "armory/orca-armory",
        "tag": "2022.08.31.18.41.10.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "8a4ec7e9ffae1760addff03861b488ede6a7458b"
      }
    },
    "name": "orca-armory"
  }
}
```