### PR TITLE
chore(cd): update orca-armory version to 2022.09.06.20.01.44.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:a07f498bda756da05e413592a551fe9fb3cba8c6ef17c2c7520636cfe1f6a586
+      imageId: sha256:2d608f841014db411237260128daa806eda02b5252a36c4f6b569bc0b7884d92
       repository: armory/orca-armory
-      tag: 2022.04.04.16.22.09.master
+      tag: 2022.09.06.20.01.44.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 238fc61ed93dd33702377f756455b44fff5acb5d
+      sha: 4faa40f1f6de496d227538193ab8f6bdf1e15109
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "2001d23ba8c08849dcf7adfbf02a74086f24ce81"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:2d608f841014db411237260128daa806eda02b5252a36c4f6b569bc0b7884d92",
        "repository": "armory/orca-armory",
        "tag": "2022.09.06.20.01.44.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "4faa40f1f6de496d227538193ab8f6bdf1e15109"
      }
    },
    "name": "orca-armory"
  }
}
```