### PR TITLE
chore(cd): update front50-armory version to 2022.09.07.21.56.45.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:cdd734ff6a86254155b4d9fbd47877df656c495d5fa372eb75109c215a9f6541
+      imageId: sha256:aab634207a3acb4a50cee21ff67e325d000a0eb268460243a656ef7dcda0993f
       repository: armory/front50-armory
-      tag: 2022.08.17.01.12.06.release-2.27.x
+      tag: 2022.09.07.21.56.45.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: a05405308878a6278522793b0d55f0f8a06cb6a5
+      sha: 2b4c0886ee46108dbca50500cefde88b0e64ce9b
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "1fc1c6673ef5a5e217e1826bd4bf574a18f866f3"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:aab634207a3acb4a50cee21ff67e325d000a0eb268460243a656ef7dcda0993f",
        "repository": "armory/front50-armory",
        "tag": "2022.09.07.21.56.45.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "2b4c0886ee46108dbca50500cefde88b0e64ce9b"
      }
    },
    "name": "front50-armory"
  }
}
```