### PR TITLE
chore(cd): update clouddriver-armory version to 2022.09.12.19.35.13.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:f25b0e1772c742ac9600a0384cfe35ca11d74b16443d48c67911af057f9af54d
+      imageId: sha256:5fdf8baeba0ec8fd5b602742c916f32a88181027b5e460d961f3832910ae3952
       repository: armory/clouddriver-armory
-      tag: 2022.09.09.20.27.11.master
+      tag: 2022.09.12.19.35.13.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 60f7d0c150e8b87fb4f504bbf2f0208faa6f6908
+      sha: ee3bc40f7c58ce0574896af919ebc4bfcecc8048
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "fa75e6bdad8ddfb7424584bc16c9d502ace4600f"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:5fdf8baeba0ec8fd5b602742c916f32a88181027b5e460d961f3832910ae3952",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.09.12.19.35.13.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ee3bc40f7c58ce0574896af919ebc4bfcecc8048"
      }
    },
    "name": "clouddriver-armory"
  }
}
```