### PR TITLE
chore(cd): update front50-armory version to 2022.09.12.22.50.10.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:aab634207a3acb4a50cee21ff67e325d000a0eb268460243a656ef7dcda0993f
+      imageId: sha256:91b59e23af363b7314cbc9fec9c99821e8e040ad276799ba07343e85a1acfeaf
       repository: armory/front50-armory
-      tag: 2022.09.07.21.56.45.release-2.27.x
+      tag: 2022.09.12.22.50.10.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 2b4c0886ee46108dbca50500cefde88b0e64ce9b
+      sha: 8be88a5e2efdf5ac85b6ea38c264d762e8ccf523
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "front50",
        "type": "github"
      },
      "sha": "1fc1c6673ef5a5e217e1826bd4bf574a18f866f3"
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:91b59e23af363b7314cbc9fec9c99821e8e040ad276799ba07343e85a1acfeaf",
        "repository": "armory/front50-armory",
        "tag": "2022.09.12.22.50.10.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "8be88a5e2efdf5ac85b6ea38c264d762e8ccf523"
      }
    },
    "name": "front50-armory"
  }
}
```