### PR TITLE
chore(cd): update echo-armory version to 2022.09.27.18.43.47.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:253d6cff4c50f2748289df708fc444bb94723b4198865f05d649367723447b65
+      imageId: sha256:da762caf687e9d0398e05c10cdfa2e8434ed358f6f8350c9cbc403957f9b290e
       repository: armory/echo-armory
-      tag: 2022.09.14.16.38.52.master
+      tag: 2022.09.27.18.43.47.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: bd39fc4fdbe840755a56b61aded3815b3cd038f0
+      sha: 42afd2c8a836df4cad92c99d7ea22f4ea8da493b
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "b301d49441030ac18b0902f11734a3eddea145a7"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:da762caf687e9d0398e05c10cdfa2e8434ed358f6f8350c9cbc403957f9b290e",
        "repository": "armory/echo-armory",
        "tag": "2022.09.27.18.43.47.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "42afd2c8a836df4cad92c99d7ea22f4ea8da493b"
      }
    },
    "name": "echo-armory"
  }
}
```