### PR TITLE
chore(cd): update orca-armory version to 2022.09.27.19.23.07.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:a07f498bda756da05e413592a551fe9fb3cba8c6ef17c2c7520636cfe1f6a586
+      imageId: sha256:4f8554470eb0c0cc68b62e34456446d79bf4ebfb9f1a6831627859acab27b093
       repository: armory/orca-armory
-      tag: 2022.04.04.16.22.09.master
+      tag: 2022.09.27.19.23.07.master
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 238fc61ed93dd33702377f756455b44fff5acb5d
+      sha: 22615001f85343047a1b05277b39187a65934b7a
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "ad614d2b8e1fa3f0ab1ec48972072d9a06e4fbff"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:4f8554470eb0c0cc68b62e34456446d79bf4ebfb9f1a6831627859acab27b093",
        "repository": "armory/orca-armory",
        "tag": "2022.09.27.19.23.07.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "22615001f85343047a1b05277b39187a65934b7a"
      }
    },
    "name": "orca-armory"
  }
}
```