### PR TITLE
chore(cd): update clouddriver-armory version to 2022.09.27.20.03.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:e880b3ceeafab8b1253441a2e7033c5ed20f427273f311a96fa0db72172db498
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.09.27.20.03.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: dbd48480eed4f9452340a1ad01b41799b4d8741b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "9ca50f1b7a0e48a4c12fdcc722cbe1252db89153"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:e880b3ceeafab8b1253441a2e7033c5ed20f427273f311a96fa0db72172db498",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.09.27.20.03.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "dbd48480eed4f9452340a1ad01b41799b4d8741b"
      }
    },
    "name": "clouddriver-armory"
  }
}
```