### PR TITLE
chore(cd): update echo-armory version to 2022.10.03.15.46.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:253d6cff4c50f2748289df708fc444bb94723b4198865f05d649367723447b65
+      imageId: sha256:3cdc03025f3b4bbbe5c2c2674971a24c4fb6cd1ad8fb7fc27919d09520a56853
       repository: armory/echo-armory
-      tag: 2022.09.14.16.38.52.master
+      tag: 2022.10.03.15.46.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: bd39fc4fdbe840755a56b61aded3815b3cd038f0
+      sha: fa61e28b193d87a7955d0b8afe0e22c418a3c9f2
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "e3410358019db0412f3ef89d1e1dcb50c0ddb4fb"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:3cdc03025f3b4bbbe5c2c2674971a24c4fb6cd1ad8fb7fc27919d09520a56853",
        "repository": "armory/echo-armory",
        "tag": "2022.10.03.15.46.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "fa61e28b193d87a7955d0b8afe0e22c418a3c9f2"
      }
    },
    "name": "echo-armory"
  }
}
```