### PR TITLE
chore(cd): update deck-armory version to 2022.10.06.15.35.18.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:ebb903df95007596fa4d7bba2b5faf7c057739eb627fec798ffd381359265f4c
+      imageId: sha256:5f445df38198302700b20a00c9d9293a5e9cc8d5228cd12d04ce9c8cc8a5b719
       repository: armory/deck-armory
-      tag: 2022.07.14.16.52.46.release-2.28.x
+      tag: 2022.10.06.15.35.18.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 108847b83576abf24d437a0c89015a65f337ec54
+      sha: 0b5e8965d448abf0df3fe25eab2ae2de0577ee6d
   dinghy:
     baseService: null
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "8cc829378c0132ce42381d8769ca2f2df0316ca1"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:5f445df38198302700b20a00c9d9293a5e9cc8d5228cd12d04ce9c8cc8a5b719",
        "repository": "armory/deck-armory",
        "tag": "2022.10.06.15.35.18.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "0b5e8965d448abf0df3fe25eab2ae2de0577ee6d"
      }
    },
    "name": "deck-armory"
  }
}
```