### PR TITLE
chore(cd): update clouddriver-armory version to 2022.10.10.17.28.21.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:9efa05e6ce3290311868776044e9db2264d7a7cc29576193054ab8ce7d04eb4b
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.10.10.17.28.21.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: f1bb50b5406f1a09e98caa10edd410be75f59f80
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "ab7c53723af5ee0aba21af39bf7ff72e75d85a45"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:9efa05e6ce3290311868776044e9db2264d7a7cc29576193054ab8ce7d04eb4b",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.10.17.28.21.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "f1bb50b5406f1a09e98caa10edd410be75f59f80"
      }
    },
    "name": "clouddriver-armory"
  }
}
```