### PR TITLE
chore(cd): update echo-armory version to 2022.10.10.18.38.53.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -38,15 +38,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:253d6cff4c50f2748289df708fc444bb94723b4198865f05d649367723447b65
+      imageId: sha256:deb96d9578d35e0871e0bb0fa44d9d7aac296c065fb11a89a89239675a6a4d9a
       repository: armory/echo-armory
-      tag: 2022.09.14.16.38.52.master
+      tag: 2022.10.10.18.38.53.master
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: bd39fc4fdbe840755a56b61aded3815b3cd038f0
+      sha: 0f88db3c1277e712497cc787d04319be329ef97b
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "echo",
        "type": "github"
      },
      "sha": "e3410358019db0412f3ef89d1e1dcb50c0ddb4fb"
    },
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:deb96d9578d35e0871e0bb0fa44d9d7aac296c065fb11a89a89239675a6a4d9a",
        "repository": "armory/echo-armory",
        "tag": "2022.10.10.18.38.53.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "0f88db3c1277e712497cc787d04319be329ef97b"
      }
    },
    "name": "echo-armory"
  }
}
```