### PR TITLE
chore(cd): update clouddriver-armory version to 2022.10.10.18.55.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:03c3f403402fb15c52f8f0a05af5d33de1ee84d0e6f2f4c5c370ed8036c20d93
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.10.10.18.55.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 3de75e1f4195d1ccd51f6a856a58662a96178089
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "25bed1fa85a9f75dcdc4faa453fb33baf2d7b8aa"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:03c3f403402fb15c52f8f0a05af5d33de1ee84d0e6f2f4c5c370ed8036c20d93",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.10.18.55.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3de75e1f4195d1ccd51f6a856a58662a96178089"
      }
    },
    "name": "clouddriver-armory"
  }
}
```