### PR TITLE
chore(cd): update gate-armory version to 2022.10.19.19.16.04.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:262a163e44e595b2bd41593912df361cf31f7061d0002059f5f5794621ca7a77
+      imageId: sha256:31862a952959769740e549287d2e9480bb29f2706fdf5d86cd5a64413b55c4c5
       repository: armory/gate-armory
-      tag: 2022.08.19.03.36.22.release-2.28.x
+      tag: 2022.10.19.19.16.04.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 2b2b668ac5d4cbf126190baf450116de6aa0aa4a
+      sha: 280b43c8a47b141877630c7f532499c4ddd79d3d
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "c7207a1a0cb4c84ca0883ecb4be16ee6d7c31ac0"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:31862a952959769740e549287d2e9480bb29f2706fdf5d86cd5a64413b55c4c5",
        "repository": "armory/gate-armory",
        "tag": "2022.10.19.19.16.04.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "280b43c8a47b141877630c7f532499c4ddd79d3d"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "c7207a1a0cb4c84ca0883ecb4be16ee6d7c31ac0"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:31862a952959769740e549287d2e9480bb29f2706fdf5d86cd5a64413b55c4c5",
        "repository": "armory/gate-armory",
        "tag": "2022.10.19.19.16.04.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "280b43c8a47b141877630c7f532499c4ddd79d3d"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```