### PR TITLE
chore(cd): update orca-armory version to 2022.10.19.21.04.24.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -110,15 +110,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:2c544411754ce7ed14984196a26d9ed323f24298b60539e94ff2b8bc71ae488d
+      imageId: sha256:737757dc749d333f7289b56a6ea60118081769a1f3c1bd31c7c4e69d1090a9ff
       repository: armory/orca-armory
-      tag: 2022.08.19.16.44.17.release-2.28.x
+      tag: 2022.10.19.21.04.24.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 727e9dd1c99b1b32e4538c65e012f448a395276a
+      sha: 2315edcd8c918c3b2baceae6742c757cb9d36c38
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c69ccc78a723b3969201df65fa0444d301fc7955"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:737757dc749d333f7289b56a6ea60118081769a1f3c1bd31c7c4e69d1090a9ff",
        "repository": "armory/orca-armory",
        "tag": "2022.10.19.21.04.24.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "2315edcd8c918c3b2baceae6742c757cb9d36c38"
      }
    },
    "name": "orca-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c69ccc78a723b3969201df65fa0444d301fc7955"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:737757dc749d333f7289b56a6ea60118081769a1f3c1bd31c7c4e69d1090a9ff",
        "repository": "armory/orca-armory",
        "tag": "2022.10.19.21.04.24.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "2315edcd8c918c3b2baceae6742c757cb9d36c38"
      }
    },
    "name": "orca-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```