### PR TITLE
chore(cd): update clouddriver-armory version to 2022.10.20.19.43.50.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:89e25dc12af4d9d3fbbd8c5f6d620c319afb6b45df49729873bdaf496989cf6c
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.10.20.19.43.50.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 400a47caa5985f311ffa0abb26268bb4004f29fd
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:89e25dc12af4d9d3fbbd8c5f6d620c319afb6b45df49729873bdaf496989cf6c",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.20.19.43.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "400a47caa5985f311ffa0abb26268bb4004f29fd"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:89e25dc12af4d9d3fbbd8c5f6d620c319afb6b45df49729873bdaf496989cf6c",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.20.19.43.50.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "400a47caa5985f311ffa0abb26268bb4004f29fd"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```