### PR TITLE
chore(cd): update deck-armory version to 2022.10.21.17.15.28.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:ebb903df95007596fa4d7bba2b5faf7c057739eb627fec798ffd381359265f4c
+      imageId: sha256:86640df898c979b20234eeaaa03918ee0cc80e528c834c2c246b174fdd563a71
       repository: armory/deck-armory
-      tag: 2022.07.14.16.52.46.release-2.28.x
+      tag: 2022.10.21.17.15.28.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 108847b83576abf24d437a0c89015a65f337ec54
+      sha: e2f05e01e2f3a69fbaee026a2aece3efd7be69fb
   dinghy:
     image:
       imageId: sha256:b5f35d09884647a6b8ff9ac6e4bc34ce27def1af573f20786ff252531768a24d


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "102be81644d61fff46f557fe7d2ba7183eefe484"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:86640df898c979b20234eeaaa03918ee0cc80e528c834c2c246b174fdd563a71",
        "repository": "armory/deck-armory",
        "tag": "2022.10.21.17.15.28.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e2f05e01e2f3a69fbaee026a2aece3efd7be69fb"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "102be81644d61fff46f557fe7d2ba7183eefe484"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:86640df898c979b20234eeaaa03918ee0cc80e528c834c2c246b174fdd563a71",
        "repository": "armory/deck-armory",
        "tag": "2022.10.21.17.15.28.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e2f05e01e2f3a69fbaee026a2aece3efd7be69fb"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```