### PR TITLE
chore(cd): update clouddriver-armory version to 2022.10.21.22.29.28.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:1b4420ed88726643a8205ddf381fe3037867747f6f23aaab0d50d09d73ddf866
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.10.21.22.29.28.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: ae1fa0109e93c6fcd1645721cd33782abc6409bc
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "e713e2499adbc3980f8b313b054420536058dfde"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1b4420ed88726643a8205ddf381fe3037867747f6f23aaab0d50d09d73ddf866",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.21.22.29.28.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ae1fa0109e93c6fcd1645721cd33782abc6409bc"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "e713e2499adbc3980f8b313b054420536058dfde"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1b4420ed88726643a8205ddf381fe3037867747f6f23aaab0d50d09d73ddf866",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.21.22.29.28.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "ae1fa0109e93c6fcd1645721cd33782abc6409bc"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```