### PR TITLE
chore(cd): update dinghy version to 2022.10.22.00.16.44.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -24,17 +24,16 @@ services:
         type: github
       sha: 108847b83576abf24d437a0c89015a65f337ec54
   dinghy:
-    baseService: null
     image:
-      imageId: sha256:525d84d08550cc084406dee400dd044d8c6f0ea9f03226bff4fa3b452b1cf3db
+      imageId: sha256:b5f35d09884647a6b8ff9ac6e4bc34ce27def1af573f20786ff252531768a24d
       repository: armory/dinghy
-      tag: 2022.08.22.19.52.29.release-2.28.x
+      tag: 2022.10.22.00.16.44.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: dinghy
         type: github
-      sha: 1859781ad9a529c45f18693e239031cf1365fe1e
+      sha: fc867f05b41e5e2756c42990b576341973e96276
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b5f35d09884647a6b8ff9ac6e4bc34ce27def1af573f20786ff252531768a24d",
        "repository": "armory/dinghy",
        "tag": "2022.10.22.00.16.44.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "fc867f05b41e5e2756c42990b576341973e96276"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:b5f35d09884647a6b8ff9ac6e4bc34ce27def1af573f20786ff252531768a24d",
        "repository": "armory/dinghy",
        "tag": "2022.10.22.00.16.44.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "fc867f05b41e5e2756c42990b576341973e96276"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```