### PR TITLE
chore(cd): update dinghy version to 2022.10.26.15.15.53.release-2.26.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -24,17 +24,16 @@ services:
         type: github
       sha: 67ad6aba719223720e1a4e8999a85471ba3963a1
   dinghy:
-    baseService: null
     image:
-      imageId: sha256:298a4b593181ef4dd9428bd646a0f08e54a3ba11db8794381323ddfb7c91c25c
+      imageId: sha256:66c8adae387ebaa4d3053d668f1cf9ab744ef324ab8a4fe440d6790fa094f821
       repository: armory/dinghy
-      tag: 2022.01.25.21.40.03.release-2.26.x
+      tag: 2022.10.26.15.15.53.release-2.26.x
     vcs:
       repo:
         orgName: armory-io
         repoName: dinghy
         type: github
-      sha: a6248311be12901a4fc8f5a3e0fae437b4347ce3
+      sha: 4c7da99314ae2b3bfe303486e3fc76cb53adce5c
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.26.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:66c8adae387ebaa4d3053d668f1cf9ab744ef324ab8a4fe440d6790fa094f821",
        "repository": "armory/dinghy",
        "tag": "2022.10.26.15.15.53.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "4c7da99314ae2b3bfe303486e3fc76cb53adce5c"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:66c8adae387ebaa4d3053d668f1cf9ab744ef324ab8a4fe440d6790fa094f821",
        "repository": "armory/dinghy",
        "tag": "2022.10.26.15.15.53.release-2.26.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "4c7da99314ae2b3bfe303486e3fc76cb53adce5c"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```