### PR TITLE
chore(cd): update dinghy version to 2022.10.27.14.21.24.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -24,17 +24,16 @@ services:
         type: github
       sha: 1b08ce5370fd95b9c4647734c36df71d729a386a
   dinghy:
-    baseService: null
     image:
-      imageId: sha256:c24fa4ab0ace8a0728627dd679133a7d1521d98dd5480d9035f860d2dec6452e
+      imageId: sha256:6276ec1156ab725a20c6e5005cb0cd6baa740e23d08601555e1226a4f328cbbb
       repository: armory/dinghy
-      tag: 2022.01.25.21.39.56.release-2.27.x
+      tag: 2022.10.27.14.21.24.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: dinghy
         type: github
-      sha: ee2e7f8b9778741dae1a5571cb47ac6c76c51d81
+      sha: ca161395d61ae5e93d1f9ecfbb503b68c2b54bc5
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6276ec1156ab725a20c6e5005cb0cd6baa740e23d08601555e1226a4f328cbbb",
        "repository": "armory/dinghy",
        "tag": "2022.10.27.14.21.24.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "ca161395d61ae5e93d1f9ecfbb503b68c2b54bc5"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:6276ec1156ab725a20c6e5005cb0cd6baa740e23d08601555e1226a4f328cbbb",
        "repository": "armory/dinghy",
        "tag": "2022.10.27.14.21.24.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "ca161395d61ae5e93d1f9ecfbb503b68c2b54bc5"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```