### PR TITLE
chore(cd): update clouddriver-armory version to 2022.10.27.14.24.32.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:4d28d2197ec075abf215615a2ae96354768782f0b1c371a0cb20e6caa522b3c7
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.10.27.14.24.32.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 8b2616cb698b1bed4cb44e74bb3a1abcbe250637
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8bec915ea207c12a5334ea8a7ca0cd09194fec74"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:4d28d2197ec075abf215615a2ae96354768782f0b1c371a0cb20e6caa522b3c7",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.27.14.24.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8b2616cb698b1bed4cb44e74bb3a1abcbe250637"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8bec915ea207c12a5334ea8a7ca0cd09194fec74"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:4d28d2197ec075abf215615a2ae96354768782f0b1c371a0cb20e6caa522b3c7",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.10.27.14.24.32.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "8b2616cb698b1bed4cb44e74bb3a1abcbe250637"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```