### PR TITLE
chore(cd): update clouddriver-armory version to 2022.11.01.19.11.06.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:078d10efee216c63be9aecd102317cf114babe087cec14725e6deebaff064eec
+      imageId: sha256:255c74a7eaaf916cf81d96407a4f306170dd1f3b68e1ae2bed5ef61389a78e20
       repository: armory/clouddriver-armory
-      tag: 2022.08.19.03.45.39.release-2.28.x
+      tag: 2022.11.01.19.11.06.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 3b1c90e3afdb77f6a3b9b607f6f98d69cb8894a0
+      sha: 9bba68d09adf45fb4d938fb19821a5692d2f003a
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0f5a2756d15494e9c05a3a08e5c4dd270f07b943"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:255c74a7eaaf916cf81d96407a4f306170dd1f3b68e1ae2bed5ef61389a78e20",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.01.19.11.06.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "9bba68d09adf45fb4d938fb19821a5692d2f003a"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0f5a2756d15494e9c05a3a08e5c4dd270f07b943"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:255c74a7eaaf916cf81d96407a4f306170dd1f3b68e1ae2bed5ef61389a78e20",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.01.19.11.06.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "9bba68d09adf45fb4d938fb19821a5692d2f003a"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```