### PR TITLE
chore(cd): update clouddriver-armory version to 2022.11.01.19.12.04.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:deeb7ebaa542e9515a74383c383ef78cd94d99ad15a12a66d35a781f27f1bfb8
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.11.01.19.12.04.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 5cff853bed5374728b6b9d308ae008cc5b58bd98
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8bec915ea207c12a5334ea8a7ca0cd09194fec74"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:deeb7ebaa542e9515a74383c383ef78cd94d99ad15a12a66d35a781f27f1bfb8",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.01.19.12.04.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5cff853bed5374728b6b9d308ae008cc5b58bd98"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "8bec915ea207c12a5334ea8a7ca0cd09194fec74"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:deeb7ebaa542e9515a74383c383ef78cd94d99ad15a12a66d35a781f27f1bfb8",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.01.19.12.04.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "5cff853bed5374728b6b9d308ae008cc5b58bd98"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```