### PR TITLE
chore(cd): update orca-armory version to 2022.11.02.03.44.17.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -109,15 +109,15 @@ services:
   orca-armory:
     baseService: orca
     image:
-      imageId: sha256:737757dc749d333f7289b56a6ea60118081769a1f3c1bd31c7c4e69d1090a9ff
+      imageId: sha256:5084920e8b9272c24eaca2df8bf75ec89316786dc616756f9f6d73512887e529
       repository: armory/orca-armory
-      tag: 2022.10.19.21.04.24.release-2.28.x
+      tag: 2022.11.02.03.44.17.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: orca-armory
         type: github
-      sha: 2315edcd8c918c3b2baceae6742c757cb9d36c38
+      sha: d64435c42a1b1d27a463241a035873968db6475f
   rosco-armory:
     baseService: rosco
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c69ccc78a723b3969201df65fa0444d301fc7955"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:5084920e8b9272c24eaca2df8bf75ec89316786dc616756f9f6d73512887e529",
        "repository": "armory/orca-armory",
        "tag": "2022.11.02.03.44.17.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "d64435c42a1b1d27a463241a035873968db6475f"
      }
    },
    "name": "orca-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "orca",
        "type": "github"
      },
      "sha": "c69ccc78a723b3969201df65fa0444d301fc7955"
    },
    "details": {
      "baseService": "orca",
      "image": {
        "imageId": "sha256:5084920e8b9272c24eaca2df8bf75ec89316786dc616756f9f6d73512887e529",
        "repository": "armory/orca-armory",
        "tag": "2022.11.02.03.44.17.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "orca-armory",
          "type": "github"
        },
        "sha": "d64435c42a1b1d27a463241a035873968db6475f"
      }
    },
    "name": "orca-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```