### PR TITLE
chore(cd): update igor-armory version to 2022.11.02.03.45.12.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -85,15 +85,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:5f64ad1eb74a6d4d85f43cb682bc8aa13b599cc5bc5a1c93f150c5992460a0d5
+      imageId: sha256:87606ac9ab8d84ab9e067d161e8d99553122fbf23c3b1a9cc41b16a7a0766aa2
       repository: armory/igor-armory
-      tag: 2022.10.19.20.13.42.release-2.28.x
+      tag: 2022.11.02.03.45.12.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: b9fd41de4d06e2c444ea8e916d8711389c9e6a2b
+      sha: e7e01c998423941507a7322e6891ea6e95a16792
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "c6801bed2e94538b836b2277f07332a027247c23"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:87606ac9ab8d84ab9e067d161e8d99553122fbf23c3b1a9cc41b16a7a0766aa2",
        "repository": "armory/igor-armory",
        "tag": "2022.11.02.03.45.12.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "e7e01c998423941507a7322e6891ea6e95a16792"
      }
    },
    "name": "igor-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "c6801bed2e94538b836b2277f07332a027247c23"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:87606ac9ab8d84ab9e067d161e8d99553122fbf23c3b1a9cc41b16a7a0766aa2",
        "repository": "armory/igor-armory",
        "tag": "2022.11.02.03.45.12.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "e7e01c998423941507a7322e6891ea6e95a16792"
      }
    },
    "name": "igor-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```