### PR TITLE
chore(cd): update igor-armory version to 2022.11.02.03.48.21.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -85,15 +85,15 @@ services:
   igor-armory:
     baseService: igor
     image:
-      imageId: sha256:56400948f1f5e2dfca9def236c748a9cd9f0e6d922b19133c47abc654b2ec9a0
+      imageId: sha256:ec75c169df03f9a4d5afb8cbdc58673378a3c99047854b2f68cfceed8a4c23d5
       repository: armory/igor-armory
-      tag: 2022.08.17.22.38.58.release-2.27.x
+      tag: 2022.11.02.03.48.21.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: igor-armory
         type: github
-      sha: cb18ff7fe94fca85ab546b4304cb9fa9ce380b69
+      sha: 2ff1a3deaaa6b9c354bc945721345d602acc19c9
   kayenta-armory:
     baseService: kayenta
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "dd51bfcdf50e4a5e037353a33746d66fd7c22be9"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:ec75c169df03f9a4d5afb8cbdc58673378a3c99047854b2f68cfceed8a4c23d5",
        "repository": "armory/igor-armory",
        "tag": "2022.11.02.03.48.21.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "2ff1a3deaaa6b9c354bc945721345d602acc19c9"
      }
    },
    "name": "igor-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "igor",
        "type": "github"
      },
      "sha": "dd51bfcdf50e4a5e037353a33746d66fd7c22be9"
    },
    "details": {
      "baseService": "igor",
      "image": {
        "imageId": "sha256:ec75c169df03f9a4d5afb8cbdc58673378a3c99047854b2f68cfceed8a4c23d5",
        "repository": "armory/igor-armory",
        "tag": "2022.11.02.03.48.21.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "igor-armory",
          "type": "github"
        },
        "sha": "2ff1a3deaaa6b9c354bc945721345d602acc19c9"
      }
    },
    "name": "igor-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```