### PR TITLE
chore(cd): update clouddriver-armory version to 2022.11.02.04.30.06.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:d707b88077a8fea61099077a7c4ad00742fc5cd93ac052a70534455ec0cf79b7
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.11.02.04.30.06.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 491f6c7aa6535fbad15f689cb02fec0544145a6e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0db8d55ff2f6a72969b7771d1a3a0c28f29740da"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:d707b88077a8fea61099077a7c4ad00742fc5cd93ac052a70534455ec0cf79b7",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.04.30.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "491f6c7aa6535fbad15f689cb02fec0544145a6e"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "0db8d55ff2f6a72969b7771d1a3a0c28f29740da"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:d707b88077a8fea61099077a7c4ad00742fc5cd93ac052a70534455ec0cf79b7",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.04.30.06.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "491f6c7aa6535fbad15f689cb02fec0544145a6e"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```