### PR TITLE
chore(cd): update clouddriver-armory version to 2022.11.02.16.11.16.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:8e5c06803d1aa4657118bbd885e06934e9460fe0fd42cced31592a665416efcd
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.11.02.16.11.16.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 3eec744cbb4de4883de7f46fcbdc5fc698410973
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "dc54e38db3379bb9af723ea8b30aeabd1fede366"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8e5c06803d1aa4657118bbd885e06934e9460fe0fd42cced31592a665416efcd",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.16.11.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3eec744cbb4de4883de7f46fcbdc5fc698410973"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "dc54e38db3379bb9af723ea8b30aeabd1fede366"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8e5c06803d1aa4657118bbd885e06934e9460fe0fd42cced31592a665416efcd",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.16.11.16.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "3eec744cbb4de4883de7f46fcbdc5fc698410973"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```