### PR TITLE
chore(cd): update clouddriver-armory version to 2022.11.02.20.20.03.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:8246131ee3823c2a61323f6d07035a6f764ef3e444a80e87f08ab7307bb273ca
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2022.11.02.20.20.03.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: 9127f22834397dfd6fb3258b442bcfe643ffd50c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "e1f20e56f7cf5a686e03c357ecad555f8c7f67eb"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8246131ee3823c2a61323f6d07035a6f764ef3e444a80e87f08ab7307bb273ca",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.20.20.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "9127f22834397dfd6fb3258b442bcfe643ffd50c"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "e1f20e56f7cf5a686e03c357ecad555f8c7f67eb"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8246131ee3823c2a61323f6d07035a6f764ef3e444a80e87f08ab7307bb273ca",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.20.20.03.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "9127f22834397dfd6fb3258b442bcfe643ffd50c"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```