### PR TITLE
chore(cd): update clouddriver-armory version to 2022.11.02.20.47.05.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:255c74a7eaaf916cf81d96407a4f306170dd1f3b68e1ae2bed5ef61389a78e20
+      imageId: sha256:c009e062eeb4450a7ba7ef0b0a39ecf983a71ebe68253f23f3b9ec0a40c228e0
       repository: armory/clouddriver-armory
-      tag: 2022.11.01.19.11.06.release-2.28.x
+      tag: 2022.11.02.20.47.05.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 9bba68d09adf45fb4d938fb19821a5692d2f003a
+      sha: 9216f0fae587d3af14ed41fb9f21e9195b30c269
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d7d0c5ab1ab19a44a09711b31b128c24d93167b1"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c009e062eeb4450a7ba7ef0b0a39ecf983a71ebe68253f23f3b9ec0a40c228e0",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.20.47.05.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "9216f0fae587d3af14ed41fb9f21e9195b30c269"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "clouddriver",
        "type": "github"
      },
      "sha": "d7d0c5ab1ab19a44a09711b31b128c24d93167b1"
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:c009e062eeb4450a7ba7ef0b0a39ecf983a71ebe68253f23f3b9ec0a40c228e0",
        "repository": "armory/clouddriver-armory",
        "tag": "2022.11.02.20.47.05.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "9216f0fae587d3af14ed41fb9f21e9195b30c269"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```