### PR TITLE
chore(cd): update deck-armory version to 2022.11.08.08.00.25.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:86640df898c979b20234eeaaa03918ee0cc80e528c834c2c246b174fdd563a71
+      imageId: sha256:2515a2f5c9a950e6d36dc01e0b27c2afa7a0ee367e1ce876022ef38d3931f249
       repository: armory/deck-armory
-      tag: 2022.10.21.17.15.28.release-2.28.x
+      tag: 2022.11.08.08.00.25.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e2f05e01e2f3a69fbaee026a2aece3efd7be69fb
+      sha: e73721f258d8aada4511f9c9821bdfe7dad6f773
   dinghy:
     image:
       imageId: sha256:b5f35d09884647a6b8ff9ac6e4bc34ce27def1af573f20786ff252531768a24d


### PR DESCRIPTION
Event
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "069dca2e9d47478931786f59f4084500286eed3c"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2515a2f5c9a950e6d36dc01e0b27c2afa7a0ee367e1ce876022ef38d3931f249",
        "repository": "armory/deck-armory",
        "tag": "2022.11.08.08.00.25.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e73721f258d8aada4511f9c9821bdfe7dad6f773"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "deck",
        "type": "github"
      },
      "sha": "069dca2e9d47478931786f59f4084500286eed3c"
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:2515a2f5c9a950e6d36dc01e0b27c2afa7a0ee367e1ce876022ef38d3931f249",
        "repository": "armory/deck-armory",
        "tag": "2022.11.08.08.00.25.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "e73721f258d8aada4511f9c9821bdfe7dad6f773"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```