### PR TITLE
chore(cd): update gate-armory version to 2022.11.10.23.04.42.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:262a163e44e595b2bd41593912df361cf31f7061d0002059f5f5794621ca7a77
+      imageId: sha256:f7f1b05687e54d4b1f2a0a76e3264733e349de4fa71ee0d24aaa114c11ee1b68
       repository: armory/gate-armory
-      tag: 2022.08.19.03.36.22.release-2.28.x
+      tag: 2022.11.10.23.04.42.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 2b2b668ac5d4cbf126190baf450116de6aa0aa4a
+      sha: 4615a016768bf7e772189da05415d654a440e107
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.28.x**

### gate-armory Image Version

armory/gate-armory:2022.11.10.23.04.42.release-2.28.x

### Service VCS

[4615a016768bf7e772189da05415d654a440e107](https://github.com/armory-io/gate-armory/commit/4615a016768bf7e772189da05415d654a440e107)

### Base Service VCS

[64f64567612facf312b7fd3126051812d10c014d](https://github.com/spinnaker/gate/commit/64f64567612facf312b7fd3126051812d10c014d)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "64f64567612facf312b7fd3126051812d10c014d"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:f7f1b05687e54d4b1f2a0a76e3264733e349de4fa71ee0d24aaa114c11ee1b68",
        "repository": "armory/gate-armory",
        "tag": "2022.11.10.23.04.42.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "4615a016768bf7e772189da05415d654a440e107"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "64f64567612facf312b7fd3126051812d10c014d"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:f7f1b05687e54d4b1f2a0a76e3264733e349de4fa71ee0d24aaa114c11ee1b68",
        "repository": "armory/gate-armory",
        "tag": "2022.11.10.23.04.42.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "4615a016768bf7e772189da05415d654a440e107"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```