### PR TITLE
chore(cd): update gate-armory version to 2022.11.17.22.19.35.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:28f8aaff13ef4cc59fec50fe05a3927fdcf6cf875aa631092a9e568bbdb9b77a
+      imageId: sha256:67b4e14ca1adece5011a8425777bf61630fe0fabeb64d0ef9ab64d47c1ac965e
       repository: armory/gate-armory
-      tag: 2022.11.10.22.54.28.master
+      tag: 2022.11.17.22.19.35.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 22e61ea13407c2e378cabd6c4b3675a9e21fd500
+      sha: f22b9d124867bb865860e9419a1c9a1e6e910cd6
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **master**

### gate-armory Image Version

armory/gate-armory:2022.11.17.22.19.35.master

### Service VCS

[f22b9d124867bb865860e9419a1c9a1e6e910cd6](https://github.com/armory-io/gate-armory/commit/f22b9d124867bb865860e9419a1c9a1e6e910cd6)

### Base Service VCS

[0e438e253524d8354c7f6f6c393b1aab3e97c64e](https://github.com/spinnaker/gate/commit/0e438e253524d8354c7f6f6c393b1aab3e97c64e)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "0e438e253524d8354c7f6f6c393b1aab3e97c64e"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:67b4e14ca1adece5011a8425777bf61630fe0fabeb64d0ef9ab64d47c1ac965e",
        "repository": "armory/gate-armory",
        "tag": "2022.11.17.22.19.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "f22b9d124867bb865860e9419a1c9a1e6e910cd6"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "0e438e253524d8354c7f6f6c393b1aab3e97c64e"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:67b4e14ca1adece5011a8425777bf61630fe0fabeb64d0ef9ab64d47c1ac965e",
        "repository": "armory/gate-armory",
        "tag": "2022.11.17.22.19.35.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "f22b9d124867bb865860e9419a1c9a1e6e910cd6"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```