### PR TITLE
chore(cd): update gate-armory version to 2022.12.01.03.50.54.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:6522dde8e03b8abe20e3507b7e4a3d86d1f418e5ab0d2d2f8ecac68da80bd615
+      imageId: sha256:f8e03bbacca701c8bf297c5d0ba47cfb181fca05bd92055d9a3fb52ac10fef6e
       repository: armory/gate-armory
-      tag: 2022.11.17.22.26.09.release-2.28.x
+      tag: 2022.12.01.03.50.54.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: eeeead3f065f60e82dbbe22df78e371132b81f09
+      sha: 65bdd30238312bbca2dce613825eda7ae88f1dfa
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.28.x**

### gate-armory Image Version

armory/gate-armory:2022.12.01.03.50.54.release-2.28.x

### Service VCS

[65bdd30238312bbca2dce613825eda7ae88f1dfa](https://github.com/armory-io/gate-armory/commit/65bdd30238312bbca2dce613825eda7ae88f1dfa)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:f8e03bbacca701c8bf297c5d0ba47cfb181fca05bd92055d9a3fb52ac10fef6e",
        "repository": "armory/gate-armory",
        "tag": "2022.12.01.03.50.54.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "65bdd30238312bbca2dce613825eda7ae88f1dfa"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:f8e03bbacca701c8bf297c5d0ba47cfb181fca05bd92055d9a3fb52ac10fef6e",
        "repository": "armory/gate-armory",
        "tag": "2022.12.01.03.50.54.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "65bdd30238312bbca2dce613825eda7ae88f1dfa"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```