### PR TITLE
chore(cd): update echo-armory version to 2022.12.06.20.33.41.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -37,15 +37,15 @@ services:
   echo-armory:
     baseService: echo
     image:
-      imageId: sha256:ba504a329d53beab2c12cb44d6a5a9f140fbd0bcc5092959afb5a52bd28179f6
+      imageId: sha256:d68d89642440483b824ae20361e1095a13245112c52cfc0e260d073449c6e0c3
       repository: armory/echo-armory
-      tag: 2022.11.29.22.24.33.release-2.28.x
+      tag: 2022.12.06.20.33.41.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: echo-armory
         type: github
-      sha: b0a56058fbfe6f49f3c3032d5a9a42b625fe1d9d
+      sha: 6d4e4ae054b7a13050a1d271b3c771a790e27fc6
   fiat-armory:
     baseService: fiat
     image:


### PR DESCRIPTION
## Promotion Of New echo-armory Version

### Release Branch

* **release-2.28.x**

### echo-armory Image Version

armory/echo-armory:2022.12.06.20.33.41.release-2.28.x

### Service VCS

[6d4e4ae054b7a13050a1d271b3c771a790e27fc6](https://github.com/armory-io/echo-armory/commit/6d4e4ae054b7a13050a1d271b3c771a790e27fc6)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:d68d89642440483b824ae20361e1095a13245112c52cfc0e260d073449c6e0c3",
        "repository": "armory/echo-armory",
        "tag": "2022.12.06.20.33.41.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "6d4e4ae054b7a13050a1d271b3c771a790e27fc6"
      }
    },
    "name": "echo-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "echo",
      "image": {
        "imageId": "sha256:d68d89642440483b824ae20361e1095a13245112c52cfc0e260d073449c6e0c3",
        "repository": "armory/echo-armory",
        "tag": "2022.12.06.20.33.41.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "echo-armory",
          "type": "github"
        },
        "sha": "6d4e4ae054b7a13050a1d271b3c771a790e27fc6"
      }
    },
    "name": "echo-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```