### PR TITLE
chore(cd): update terraformer version to 2023.01.05.17.01.46.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -132,12 +132,12 @@ services:
       sha: 945f21dec252da7dd2e00c8d23a1687aa3b9841a
   terraformer:
     image:
-      imageId: sha256:9d425ad59a69f3f303005661d1ec783631a0fc4c68c5db8402ad9af1b743b16b
+      imageId: sha256:8905a5c4d92cd660d6d548463d303a2e39edcf865c5dbb40291fa04eb7d6d72b
       repository: armory/terraformer
-      tag: 2022.12.14.20.52.44.release-2.28.x
+      tag: 2023.01.05.17.01.46.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 0d18998cb4790dd4857d79e318d873450bd5975d
+      sha: 6c6f5dc080b5f39ed3ee0be45f0ac0790bc1afa2


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.28.x**

### terraformer Image Version

armory/terraformer:2023.01.05.17.01.46.release-2.28.x

### Service VCS

[6c6f5dc080b5f39ed3ee0be45f0ac0790bc1afa2](https://github.com/armory-io/terraformer/commit/6c6f5dc080b5f39ed3ee0be45f0ac0790bc1afa2)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8905a5c4d92cd660d6d548463d303a2e39edcf865c5dbb40291fa04eb7d6d72b",
        "repository": "armory/terraformer",
        "tag": "2023.01.05.17.01.46.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "6c6f5dc080b5f39ed3ee0be45f0ac0790bc1afa2"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:8905a5c4d92cd660d6d548463d303a2e39edcf865c5dbb40291fa04eb7d6d72b",
        "repository": "armory/terraformer",
        "tag": "2023.01.05.17.01.46.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "6c6f5dc080b5f39ed3ee0be45f0ac0790bc1afa2"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```