### PR TITLE
chore(cd): update terraformer version to 2023.01.05.17.01.57.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -132,12 +132,12 @@ services:
       sha: f4164fdcfa275b62e0c0fefbe26b5cbd845c543d
   terraformer:
     image:
-      imageId: sha256:9ff21004515623b711c86ac1c8487f45a0e51a04711b7b1bfc926d28736621cf
+      imageId: sha256:2d1f7e353c952c68c9399b2827762cee3651d36e748838a84ab568b372f3bb3e
       repository: armory/terraformer
-      tag: 2022.12.14.21.17.39.release-2.27.x
+      tag: 2023.01.05.17.01.57.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: c0ee8b6f421a42e451b7016298365e493be5dd89
+      sha: 7620bcfec61334c92de8f29e4f52dc2325e3d81c


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.27.x**

### terraformer Image Version

armory/terraformer:2023.01.05.17.01.57.release-2.27.x

### Service VCS

[7620bcfec61334c92de8f29e4f52dc2325e3d81c](https://github.com/armory-io/terraformer/commit/7620bcfec61334c92de8f29e4f52dc2325e3d81c)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2d1f7e353c952c68c9399b2827762cee3651d36e748838a84ab568b372f3bb3e",
        "repository": "armory/terraformer",
        "tag": "2023.01.05.17.01.57.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "7620bcfec61334c92de8f29e4f52dc2325e3d81c"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:2d1f7e353c952c68c9399b2827762cee3651d36e748838a84ab568b372f3bb3e",
        "repository": "armory/terraformer",
        "tag": "2023.01.05.17.01.57.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "7620bcfec61334c92de8f29e4f52dc2325e3d81c"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```