### PR TITLE
chore(cd): update gate-armory version to 2022.11.17.22.19.35.release-2.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,9 +73,9 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:67b4e14ca1adece5011a8425777bf61630fe0fabeb64d0ef9ab64d47c1ac965e
+      imageId: sha256:64a16e850f1321729c2107d78fcafd941049df78bc9e545698a01f0c186fdf96
       repository: armory/gate-armory
-      tag: 2022.11.17.22.19.35.master
+      tag: 2022.11.17.22.19.35.release-2.29.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.29.x**

### gate-armory Image Version

armory/gate-armory:2022.11.17.22.19.35.release-2.29.x

### Service VCS

[f22b9d124867bb865860e9419a1c9a1e6e910cd6](https://github.com/armory-io/gate-armory/commit/f22b9d124867bb865860e9419a1c9a1e6e910cd6)

### Base Service VCS

[0e438e253524d8354c7f6f6c393b1aab3e97c64e](https://github.com/spinnaker/gate/commit/0e438e253524d8354c7f6f6c393b1aab3e97c64e)

Event Payload
```
{
  "branch": "release-2.29.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "0e438e253524d8354c7f6f6c393b1aab3e97c64e"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:64a16e850f1321729c2107d78fcafd941049df78bc9e545698a01f0c186fdf96",
        "repository": "armory/gate-armory",
        "tag": "2022.11.17.22.19.35.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "f22b9d124867bb865860e9419a1c9a1e6e910cd6"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "0e438e253524d8354c7f6f6c393b1aab3e97c64e"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:64a16e850f1321729c2107d78fcafd941049df78bc9e545698a01f0c186fdf96",
        "repository": "armory/gate-armory",
        "tag": "2022.11.17.22.19.35.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "f22b9d124867bb865860e9419a1c9a1e6e910cd6"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```