### PR TITLE
chore(cd): update clouddriver-armory version to 2023.02.08.03.03.38.release-2.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:631fc0c6acbdef40bd9e9b1546b898388c3207ad373ea055f191580910ee02db
+      imageId: sha256:b11a20c4256a4b2e8e6214ebc09e899caa2d8315356ace3c57691bce49335519
       repository: armory/clouddriver-armory
-      tag: 2022.09.14.17.01.20.master
+      tag: 2023.02.08.03.03.38.release-2.29.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 8a0b6b34ffcdd4b0b749a0452a339282bedda7eb
+      sha: d82d619088aeeee0b76c96b6fe0809b7d723f150
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.29.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2023.02.08.03.03.38.release-2.29.x

### Service VCS

[d82d619088aeeee0b76c96b6fe0809b7d723f150](https://github.com/armory-io/clouddriver-armory/commit/d82d619088aeeee0b76c96b6fe0809b7d723f150)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:b11a20c4256a4b2e8e6214ebc09e899caa2d8315356ace3c57691bce49335519",
        "repository": "armory/clouddriver-armory",
        "tag": "2023.02.08.03.03.38.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d82d619088aeeee0b76c96b6fe0809b7d723f150"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:b11a20c4256a4b2e8e6214ebc09e899caa2d8315356ace3c57691bce49335519",
        "repository": "armory/clouddriver-armory",
        "tag": "2023.02.08.03.03.38.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "d82d619088aeeee0b76c96b6fe0809b7d723f150"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```