### PR TITLE
chore(cd): update clouddriver-armory version to 2023.02.25.00.41.05.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:db1b28e2be1355ffeb662acc0399dee3e1f49cebf13b3a16d696452d252561fa
+      imageId: sha256:a35cb910b0becc05df04364e6aa64184d2fa53257283cd6e4cd9ec98bf5ea845
       repository: armory/clouddriver-armory
-      tag: 2023.02.23.17.41.23.master
+      tag: 2023.02.25.00.41.05.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: ba836d1e6e2825c0745caec226a57858836b3ec9
+      sha: 6566d73edd731789f8e50b503e3308efe2a76da0
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **master**

### clouddriver-armory Image Version

armory/clouddriver-armory:2023.02.25.00.41.05.master

### Service VCS

[6566d73edd731789f8e50b503e3308efe2a76da0](https://github.com/armory-io/clouddriver-armory/commit/6566d73edd731789f8e50b503e3308efe2a76da0)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a35cb910b0becc05df04364e6aa64184d2fa53257283cd6e4cd9ec98bf5ea845",
        "repository": "armory/clouddriver-armory",
        "tag": "2023.02.25.00.41.05.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6566d73edd731789f8e50b503e3308efe2a76da0"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a35cb910b0becc05df04364e6aa64184d2fa53257283cd6e4cd9ec98bf5ea845",
        "repository": "armory/clouddriver-armory",
        "tag": "2023.02.25.00.41.05.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "6566d73edd731789f8e50b503e3308efe2a76da0"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```