### PR TITLE
chore(cd): update front50-armory version to 2023.01.11.00.11.56.release-2.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -61,15 +61,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:1d0dc4de0f08c948bddf1ad1f760981b4f5fff063d19e8853f82227c3880296b
+      imageId: sha256:5312299a0f13fe3804e7da4a5787fa08378230afe3d2be5de31b3448e1cd793f
       repository: armory/front50-armory
-      tag: 2022.07.08.02.40.47.master
+      tag: 2023.01.11.00.11.56.release-2.29.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: b8ea85489ae8ba7f09e93573a364e9ba4c3512fb
+      sha: 5a957be754e0a61fc5b69e67cba6089768722b20
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.29.x**

### front50-armory Image Version

armory/front50-armory:2023.01.11.00.11.56.release-2.29.x

### Service VCS

[5a957be754e0a61fc5b69e67cba6089768722b20](https://github.com/armory-io/front50-armory/commit/5a957be754e0a61fc5b69e67cba6089768722b20)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:5312299a0f13fe3804e7da4a5787fa08378230afe3d2be5de31b3448e1cd793f",
        "repository": "armory/front50-armory",
        "tag": "2023.01.11.00.11.56.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "5a957be754e0a61fc5b69e67cba6089768722b20"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:5312299a0f13fe3804e7da4a5787fa08378230afe3d2be5de31b3448e1cd793f",
        "repository": "armory/front50-armory",
        "tag": "2023.01.11.00.11.56.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "5a957be754e0a61fc5b69e67cba6089768722b20"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```