### PR TITLE
chore(cd): update gate-armory version to 2023.01.11.00.11.13.release-2.29.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:67b4e14ca1adece5011a8425777bf61630fe0fabeb64d0ef9ab64d47c1ac965e
+      imageId: sha256:ed8ca9c070934d8782be6f457dd5e70d20579ec7fb021696ddfe03854361e109
       repository: armory/gate-armory
-      tag: 2022.11.17.22.19.35.master
+      tag: 2023.01.11.00.11.13.release-2.29.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: f22b9d124867bb865860e9419a1c9a1e6e910cd6
+      sha: 437065ccf4815f0349d22ff6d4fcb71b648847b0
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.29.x**

### gate-armory Image Version

armory/gate-armory:2023.01.11.00.11.13.release-2.29.x

### Service VCS

[437065ccf4815f0349d22ff6d4fcb71b648847b0](https://github.com/armory-io/gate-armory/commit/437065ccf4815f0349d22ff6d4fcb71b648847b0)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.29.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:ed8ca9c070934d8782be6f457dd5e70d20579ec7fb021696ddfe03854361e109",
        "repository": "armory/gate-armory",
        "tag": "2023.01.11.00.11.13.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "437065ccf4815f0349d22ff6d4fcb71b648847b0"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:ed8ca9c070934d8782be6f457dd5e70d20579ec7fb021696ddfe03854361e109",
        "repository": "armory/gate-armory",
        "tag": "2023.01.11.00.11.13.release-2.29.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "437065ccf4815f0349d22ff6d4fcb71b648847b0"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```