### PR TITLE
chore(cd): update gate-armory version to 2023.03.02.20.08.55.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:f8e03bbacca701c8bf297c5d0ba47cfb181fca05bd92055d9a3fb52ac10fef6e
+      imageId: sha256:5b7e8cdf2ea5751c2a4b5639cfad87a24c0539be89d7041da797d9da97e06b5a
       repository: armory/gate-armory
-      tag: 2022.12.01.03.50.54.release-2.28.x
+      tag: 2023.03.02.20.08.55.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 65bdd30238312bbca2dce613825eda7ae88f1dfa
+      sha: 1a80457eb71adb98f3c3fcc54b27a046e384cf80
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.28.x**

### gate-armory Image Version

armory/gate-armory:2023.03.02.20.08.55.release-2.28.x

### Service VCS

[1a80457eb71adb98f3c3fcc54b27a046e384cf80](https://github.com/armory-io/gate-armory/commit/1a80457eb71adb98f3c3fcc54b27a046e384cf80)

### Base Service VCS

[338034da9c2b6f2ea09a46820294998d70a13f6e](https://github.com/spinnaker/gate/commit/338034da9c2b6f2ea09a46820294998d70a13f6e)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "338034da9c2b6f2ea09a46820294998d70a13f6e"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:5b7e8cdf2ea5751c2a4b5639cfad87a24c0539be89d7041da797d9da97e06b5a",
        "repository": "armory/gate-armory",
        "tag": "2023.03.02.20.08.55.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "1a80457eb71adb98f3c3fcc54b27a046e384cf80"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "338034da9c2b6f2ea09a46820294998d70a13f6e"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:5b7e8cdf2ea5751c2a4b5639cfad87a24c0539be89d7041da797d9da97e06b5a",
        "repository": "armory/gate-armory",
        "tag": "2023.03.02.20.08.55.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "1a80457eb71adb98f3c3fcc54b27a046e384cf80"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```