### PR TITLE
chore(cd): update dinghy version to 2023.03.06.08.27.31.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -25,15 +25,15 @@ services:
       sha: be6776c69c18743de1df214acaa500250569a146
   dinghy:
     image:
-      imageId: sha256:6276ec1156ab725a20c6e5005cb0cd6baa740e23d08601555e1226a4f328cbbb
+      imageId: sha256:ee0b1ac95d4cee35baf5a773be9ddeccb45221c928f4c2c3725e4874437937cf
       repository: armory/dinghy
-      tag: 2022.10.27.14.21.24.release-2.27.x
+      tag: 2023.03.06.08.27.31.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: dinghy
         type: github
-      sha: ca161395d61ae5e93d1f9ecfbb503b68c2b54bc5
+      sha: 4724296b0bece7ee155252c65f097d0cbe374acd
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
## Promotion Of New dinghy Version

### Release Branch

* **release-2.27.x**

### dinghy Image Version

armory/dinghy:2023.03.06.08.27.31.release-2.27.x

### Service VCS

[4724296b0bece7ee155252c65f097d0cbe374acd](https://github.com/armory-io/dinghy/commit/4724296b0bece7ee155252c65f097d0cbe374acd)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ee0b1ac95d4cee35baf5a773be9ddeccb45221c928f4c2c3725e4874437937cf",
        "repository": "armory/dinghy",
        "tag": "2023.03.06.08.27.31.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "4724296b0bece7ee155252c65f097d0cbe374acd"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:ee0b1ac95d4cee35baf5a773be9ddeccb45221c928f4c2c3725e4874437937cf",
        "repository": "armory/dinghy",
        "tag": "2023.03.06.08.27.31.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "dinghy",
          "type": "github"
        },
        "sha": "4724296b0bece7ee155252c65f097d0cbe374acd"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```