### PR TITLE
chore(cd): update terraformer version to 2023.03.15.01.36.31.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -132,12 +132,12 @@ services:
       sha: 8b94ccff09fe762d896df9052e4199af6dd9b666
   terraformer:
     image:
-      imageId: sha256:082054c1344df4d2e3bf137f3ee4e821a9850e6ab40b0bbb87446900d30d4167
+      imageId: sha256:24f00b24e02b72f0344544d7731f509c096b1a6bf14ef34278f14c256edfb1e8
       repository: armory/terraformer
-      tag: 2023.01.05.17.37.14.release-2.27.x
+      tag: 2023.03.15.01.36.31.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: f845ba2fc760c46b98794a10c32cc2b713c7c9e0
+      sha: 736ece67b4a52a612262cbe844d1edd3ad176d19


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.27.x**

### terraformer Image Version

armory/terraformer:2023.03.15.01.36.31.release-2.27.x

### Service VCS

[736ece67b4a52a612262cbe844d1edd3ad176d19](https://github.com/armory-io/terraformer/commit/736ece67b4a52a612262cbe844d1edd3ad176d19)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:24f00b24e02b72f0344544d7731f509c096b1a6bf14ef34278f14c256edfb1e8",
        "repository": "armory/terraformer",
        "tag": "2023.03.15.01.36.31.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "736ece67b4a52a612262cbe844d1edd3ad176d19"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:24f00b24e02b72f0344544d7731f509c096b1a6bf14ef34278f14c256edfb1e8",
        "repository": "armory/terraformer",
        "tag": "2023.03.15.01.36.31.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "736ece67b4a52a612262cbe844d1edd3ad176d19"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```