### PR TITLE
chore(cd): update deck-armory version to 2023.05.01.05.50.20.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:507b5106a05ccb37e21e8253d8542048f96fbca0d1184f807c23dfe0d53b4424
+      imageId: sha256:87ee380c047e59168d71411e1b26adcf8823bb65b63ec03ef5c10fbdb1812692
       repository: armory/deck-armory
-      tag: 2023.04.20.20.06.27.release-2.28.x
+      tag: 2023.05.01.05.50.20.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: e24db15a97545fd5dda3bdb88a70f640bc5a1104
+      sha: 5e7cef7a443e096cf8158c0c405c3ebbf8b97c35
   dinghy:
     image:
       imageId: sha256:45ab1532bbb9d48da50951e110e7283ec6a9fc312db6fcb4bd0cc8a7860c35e5


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.28.x**

### deck-armory Image Version

armory/deck-armory:2023.05.01.05.50.20.release-2.28.x

### Service VCS

[5e7cef7a443e096cf8158c0c405c3ebbf8b97c35](https://github.com/armory-io/deck-armory/commit/5e7cef7a443e096cf8158c0c405c3ebbf8b97c35)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:87ee380c047e59168d71411e1b26adcf8823bb65b63ec03ef5c10fbdb1812692",
        "repository": "armory/deck-armory",
        "tag": "2023.05.01.05.50.20.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "5e7cef7a443e096cf8158c0c405c3ebbf8b97c35"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:87ee380c047e59168d71411e1b26adcf8823bb65b63ec03ef5c10fbdb1812692",
        "repository": "armory/deck-armory",
        "tag": "2023.05.01.05.50.20.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "5e7cef7a443e096cf8158c0c405c3ebbf8b97c35"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```