### PR TITLE
chore(cd): update terraformer version to 2023.08.16.23.46.21.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -132,12 +132,12 @@ services:
       sha: 27d4a2b4a1d5f099b68471303d4fd14af156d46d
   terraformer:
     image:
-      imageId: sha256:bdc895d272fa3064cf48b00031851e42710c3dd4e865d30f25f69aa8267f746b
+      imageId: sha256:dc7336eb264ea5902f36550dc80461ea5d15cce005cd6c4019ef2ca6c330b986
       repository: armory/terraformer
-      tag: 2023.03.15.01.36.09.release-2.28.x
+      tag: 2023.08.16.23.46.21.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: ea9b0255b7d446bcbf0f0d4e03fc8699b7508431
+      sha: e1630e48daea8e799880f3fcdf5e694f246946d1


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.28.x**

### terraformer Image Version

armory/terraformer:2023.08.16.23.46.21.release-2.28.x

### Service VCS

[e1630e48daea8e799880f3fcdf5e694f246946d1](https://github.com/armory-io/terraformer/commit/e1630e48daea8e799880f3fcdf5e694f246946d1)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:dc7336eb264ea5902f36550dc80461ea5d15cce005cd6c4019ef2ca6c330b986",
        "repository": "armory/terraformer",
        "tag": "2023.08.16.23.46.21.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "e1630e48daea8e799880f3fcdf5e694f246946d1"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:dc7336eb264ea5902f36550dc80461ea5d15cce005cd6c4019ef2ca6c330b986",
        "repository": "armory/terraformer",
        "tag": "2023.08.16.23.46.21.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "e1630e48daea8e799880f3fcdf5e694f246946d1"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```