### PR TITLE
chore(cd): update deck-armory version to 2023.09.21.16.43.10.release-2.27.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:edc8272e46d6dce7678bacb67da07b7e9a92e2fdde9132f52bd5fe98a24cd955
+      imageId: sha256:3f037cc2510e24d6df1ef344041bebc440af244ff02798ffe9a8d7b23ba251eb
       repository: armory/deck-armory
-      tag: 2023.04.05.07.52.39.release-2.27.x
+      tag: 2023.09.21.16.43.10.release-2.27.x
     vcs:
       repo:
         orgName: armory-io
         repoName: deck-armory
         type: github
-      sha: 2c0743383e35f64765eded0c8a5036c29b63ef08
+      sha: 65392dbd3ea90f0568653398a71c67d479892c90
   dinghy:
     image:
       imageId: sha256:40c6b3a0bf4340f5feaa2e5f0b7759b17ce78ad49e4e739eacf678e0e3bfed68


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.27.x**

### deck-armory Image Version

armory/deck-armory:2023.09.21.16.43.10.release-2.27.x

### Service VCS

[65392dbd3ea90f0568653398a71c67d479892c90](https://github.com/armory-io/deck-armory/commit/65392dbd3ea90f0568653398a71c67d479892c90)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.27.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3f037cc2510e24d6df1ef344041bebc440af244ff02798ffe9a8d7b23ba251eb",
        "repository": "armory/deck-armory",
        "tag": "2023.09.21.16.43.10.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "65392dbd3ea90f0568653398a71c67d479892c90"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3f037cc2510e24d6df1ef344041bebc440af244ff02798ffe9a8d7b23ba251eb",
        "repository": "armory/deck-armory",
        "tag": "2023.09.21.16.43.10.release-2.27.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "deck-armory",
          "type": "github"
        },
        "sha": "65392dbd3ea90f0568653398a71c67d479892c90"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```