### PR TITLE
chore(cd): update gate-armory version to 2023.09.21.17.51.18.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:eae3e5de9e13fc5c5d5ec1a7e797b51d4ad3a996eac11fb45c3b687a61abfcb1
+      imageId: sha256:28e16ff89f648fb108eb050a9a8b372b30d14d57c1986a900b8aec27acd84369
       repository: armory/gate-armory
-      tag: 2023.04.13.18.44.50.release-2.28.x
+      tag: 2023.09.21.17.51.18.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: c8058f4362f3f4ad108fa146d628a162445c7579
+      sha: 9577f3887731db748c24cb732fd91e5b840332ce
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.28.x**

### gate-armory Image Version

armory/gate-armory:2023.09.21.17.51.18.release-2.28.x

### Service VCS

[9577f3887731db748c24cb732fd91e5b840332ce](https://github.com/armory-io/gate-armory/commit/9577f3887731db748c24cb732fd91e5b840332ce)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:28e16ff89f648fb108eb050a9a8b372b30d14d57c1986a900b8aec27acd84369",
        "repository": "armory/gate-armory",
        "tag": "2023.09.21.17.51.18.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "9577f3887731db748c24cb732fd91e5b840332ce"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:28e16ff89f648fb108eb050a9a8b372b30d14d57c1986a900b8aec27acd84369",
        "repository": "armory/gate-armory",
        "tag": "2023.09.21.17.51.18.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "9577f3887731db748c24cb732fd91e5b840332ce"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```