### PR TITLE
chore(cd): update front50-armory version to 2023.10.01.17.36.02.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -61,15 +61,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:38da5a93d98deef07aad486607f707c773f471404fb5972e026aa3d8e69ca90b
+      imageId: sha256:634073ad49ac580f4f184fc68cccb05c096ae056b73e95237e337ed154b1d0f4
       repository: armory/front50-armory
-      tag: 2023.07.27.18.16.22.master
+      tag: 2023.10.01.17.36.02.master
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 445717e39fe7531b63a9a75bc990cab138ecd9c7
+      sha: ce56ccc4b2e509dd28331391766a656e3e7b1d69
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **master**

### front50-armory Image Version

armory/front50-armory:2023.10.01.17.36.02.master

### Service VCS

[ce56ccc4b2e509dd28331391766a656e3e7b1d69](https://github.com/armory-io/front50-armory/commit/ce56ccc4b2e509dd28331391766a656e3e7b1d69)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:634073ad49ac580f4f184fc68cccb05c096ae056b73e95237e337ed154b1d0f4",
        "repository": "armory/front50-armory",
        "tag": "2023.10.01.17.36.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "ce56ccc4b2e509dd28331391766a656e3e7b1d69"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:634073ad49ac580f4f184fc68cccb05c096ae056b73e95237e337ed154b1d0f4",
        "repository": "armory/front50-armory",
        "tag": "2023.10.01.17.36.02.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "ce56ccc4b2e509dd28331391766a656e3e7b1d69"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```