### PR TITLE
chore(cd): update terraformer version to 2023.03.14.19.56.35.release-2.32.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -132,9 +132,9 @@ services:
       sha: aa1a32c7576864e22a4b10ea8e5a177c6979659a
   terraformer:
     image:
-      imageId: sha256:307fed4911699ad124d3f43c0394766e723c696a03eee43a9df726412119ad4a
+      imageId: sha256:a59389cfba1d421251c546c62ca0bab8c7616eef22e2997fe47bac53d8cb08c7
       repository: armory/terraformer
-      tag: 2023.03.14.19.56.35.master
+      tag: 2023.03.14.19.56.35.release-2.32.x
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.32.x**

### terraformer Image Version

armory/terraformer:2023.03.14.19.56.35.release-2.32.x

### Service VCS

[d98a6ad23678ed1b931297104c3102b3e363c5a1](https://github.com/armory-io/terraformer/commit/d98a6ad23678ed1b931297104c3102b3e363c5a1)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.32.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a59389cfba1d421251c546c62ca0bab8c7616eef22e2997fe47bac53d8cb08c7",
        "repository": "armory/terraformer",
        "tag": "2023.03.14.19.56.35.release-2.32.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d98a6ad23678ed1b931297104c3102b3e363c5a1"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:a59389cfba1d421251c546c62ca0bab8c7616eef22e2997fe47bac53d8cb08c7",
        "repository": "armory/terraformer",
        "tag": "2023.03.14.19.56.35.release-2.32.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d98a6ad23678ed1b931297104c3102b3e363c5a1"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```