### PR TITLE
chore(cd): update gate-armory version to 2024.02.01.20.23.32.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:28e16ff89f648fb108eb050a9a8b372b30d14d57c1986a900b8aec27acd84369
+      imageId: sha256:de344fbaeb800fa008705a562bd360caafadcba63d3ac7c54cc3f99c8e639137
       repository: armory/gate-armory
-      tag: 2023.09.21.17.51.18.release-2.28.x
+      tag: 2024.02.01.20.23.32.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 9577f3887731db748c24cb732fd91e5b840332ce
+      sha: b9e691ca3199bcdc7ba6f0a6870dcfb802b9e3f7
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.28.x**

### gate-armory Image Version

armory/gate-armory:2024.02.01.20.23.32.release-2.28.x

### Service VCS

[b9e691ca3199bcdc7ba6f0a6870dcfb802b9e3f7](https://github.com/armory-io/gate-armory/commit/b9e691ca3199bcdc7ba6f0a6870dcfb802b9e3f7)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:de344fbaeb800fa008705a562bd360caafadcba63d3ac7c54cc3f99c8e639137",
        "repository": "armory/gate-armory",
        "tag": "2024.02.01.20.23.32.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "b9e691ca3199bcdc7ba6f0a6870dcfb802b9e3f7"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:de344fbaeb800fa008705a562bd360caafadcba63d3ac7c54cc3f99c8e639137",
        "repository": "armory/gate-armory",
        "tag": "2024.02.01.20.23.32.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "b9e691ca3199bcdc7ba6f0a6870dcfb802b9e3f7"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```