### PR TITLE
chore(cd): update clouddriver-armory version to 2024.02.01.21.44.55.release-2.28.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:510f271f4ac4834fcf9b277fe2c9e72bbf66c2daf895a6e3aec620afede024d0
+      imageId: sha256:eca11377b94fa3330cc6879cc7d703100050f1fb3e3f62dafa330cb566740f9f
       repository: armory/clouddriver-armory
-      tag: 2023.09.21.16.27.16.release-2.28.x
+      tag: 2024.02.01.21.44.55.release-2.28.x
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: 28e862e0f4fce10121b986645ab9eda752ee8a8d
+      sha: a03424860e7396150f3ed4b064184794330a343d
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.28.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2024.02.01.21.44.55.release-2.28.x

### Service VCS

[a03424860e7396150f3ed4b064184794330a343d](https://github.com/armory-io/clouddriver-armory/commit/a03424860e7396150f3ed4b064184794330a343d)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.28.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:eca11377b94fa3330cc6879cc7d703100050f1fb3e3f62dafa330cb566740f9f",
        "repository": "armory/clouddriver-armory",
        "tag": "2024.02.01.21.44.55.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a03424860e7396150f3ed4b064184794330a343d"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:eca11377b94fa3330cc6879cc7d703100050f1fb3e3f62dafa330cb566740f9f",
        "repository": "armory/clouddriver-armory",
        "tag": "2024.02.01.21.44.55.release-2.28.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "a03424860e7396150f3ed4b064184794330a343d"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```