### PR TITLE
chore(cd): update terraformer version to 2024.04.11.08.36.42.release-2.32.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -132,12 +132,12 @@ services:
       sha: dfe611ffdd2cf9ae7c524fb9970af47350ca5e96
   terraformer:
     image:
-      imageId: sha256:7e21a53d53ba6b140ee8365c864c0714ce4fd215b69e8239e06ec09d6f7fa0e9
+      imageId: sha256:45bfb49995a98758a157e7ff96d5b1a96e60bdac3a552ea7b97d440b82cd2e5e
       repository: armory/terraformer
-      tag: 2024.02.19.15.54.39.release-2.32.x
+      tag: 2024.04.11.08.36.42.release-2.32.x
     vcs:
       repo:
         orgName: armory-io
         repoName: terraformer
         type: github
-      sha: 6dbdb8b4c277cca4285b4d29d10f6cf3765f7590
+      sha: d88b5801f1ccae0feb75d0cfd61b3d689d67e841


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.32.x**

### terraformer Image Version

armory/terraformer:2024.04.11.08.36.42.release-2.32.x

### Service VCS

[d88b5801f1ccae0feb75d0cfd61b3d689d67e841](https://github.com/armory-io/terraformer/commit/d88b5801f1ccae0feb75d0cfd61b3d689d67e841)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.32.x",
  "service": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:45bfb49995a98758a157e7ff96d5b1a96e60bdac3a552ea7b97d440b82cd2e5e",
        "repository": "armory/terraformer",
        "tag": "2024.04.11.08.36.42.release-2.32.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d88b5801f1ccae0feb75d0cfd61b3d689d67e841"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "image": {
        "imageId": "sha256:45bfb49995a98758a157e7ff96d5b1a96e60bdac3a552ea7b97d440b82cd2e5e",
        "repository": "armory/terraformer",
        "tag": "2024.04.11.08.36.42.release-2.32.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "terraformer",
          "type": "github"
        },
        "sha": "d88b5801f1ccae0feb75d0cfd61b3d689d67e841"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```