### PR TITLE
chore(cd): update front50-armory version to 2024.08.26.11.59.52.release-2.32.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -61,15 +61,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:7c88701ce8b97f03cf6b57f5be861ffc12c21c3ff815c494d6e987e296a8c1be
+      imageId: sha256:976348271c5693ed41daa40a394bfbb7b32f937bdf54998120bddfd3ee7833b5
       repository: armory/front50-armory
-      tag: 2024.06.11.18.35.10.release-2.32.x
+      tag: 2024.08.26.11.59.52.release-2.32.x
     vcs:
       repo:
         orgName: armory-io
         repoName: front50-armory
         type: github
-      sha: 0f22731b93b51f48fc823728db69b86783679314
+      sha: e45bcd4cd5e059036982e1a23ef9360379cdaf77
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.32.x**

### front50-armory Image Version

armory/front50-armory:2024.08.26.11.59.52.release-2.32.x

### Service VCS

[e45bcd4cd5e059036982e1a23ef9360379cdaf77](https://github.com/armory-io/front50-armory/commit/e45bcd4cd5e059036982e1a23ef9360379cdaf77)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.32.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:976348271c5693ed41daa40a394bfbb7b32f937bdf54998120bddfd3ee7833b5",
        "repository": "armory/front50-armory",
        "tag": "2024.08.26.11.59.52.release-2.32.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "e45bcd4cd5e059036982e1a23ef9360379cdaf77"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:976348271c5693ed41daa40a394bfbb7b32f937bdf54998120bddfd3ee7833b5",
        "repository": "armory/front50-armory",
        "tag": "2024.08.26.11.59.52.release-2.32.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "front50-armory",
          "type": "github"
        },
        "sha": "e45bcd4cd5e059036982e1a23ef9360379cdaf77"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```