### PR TITLE
chore(cd): update gate-armory version to 2024.11.29.02.47.20.release-2.36.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:2bcf73512affabcbdf99880c544d57889c2540a29d179812c0df72d34720f622
+      imageId: sha256:62ec62b622c021824d856ef4f81e3e3720e436c706b28be537940598ec6dd8ec
       repository: armory/gate-armory
-      tag: 2024.09.19.19.19.59.master
+      tag: 2024.11.29.02.47.20.release-2.36.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 0e86b4ec67e1d44367c6f8418e43050bb861094e
+      sha: 0e5faf620267761450973a08f8d222fee1a87abe
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.36.x**

### gate-armory Image Version

armory/gate-armory:2024.11.29.02.47.20.release-2.36.x

### Service VCS

[0e5faf620267761450973a08f8d222fee1a87abe](https://github.com/armory-io/gate-armory/commit/0e5faf620267761450973a08f8d222fee1a87abe)

### Base Service VCS

[79dc08e63646c2bd70e39d63f489197913dfbc82](https://github.com/spinnaker/gate/commit/79dc08e63646c2bd70e39d63f489197913dfbc82)

Event Payload
```
{
  "branch": "release-2.36.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "79dc08e63646c2bd70e39d63f489197913dfbc82"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:62ec62b622c021824d856ef4f81e3e3720e436c706b28be537940598ec6dd8ec",
        "repository": "armory/gate-armory",
        "tag": "2024.11.29.02.47.20.release-2.36.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "0e5faf620267761450973a08f8d222fee1a87abe"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "79dc08e63646c2bd70e39d63f489197913dfbc82"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:62ec62b622c021824d856ef4f81e3e3720e436c706b28be537940598ec6dd8ec",
        "repository": "armory/gate-armory",
        "tag": "2024.11.29.02.47.20.release-2.36.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "0e5faf620267761450973a08f8d222fee1a87abe"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```