### PR TITLE
chore(cd): update gate-armory version to 2025.01.29.03.02.42.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:2bcf73512affabcbdf99880c544d57889c2540a29d179812c0df72d34720f622
+      imageId: sha256:bd30a14ec89b121ee07df16b3a68368d9b7a0b0c87e88def9470a78e4e85c8c3
       repository: armory/gate-armory
-      tag: 2024.09.19.19.19.59.master
+      tag: 2025.01.29.03.02.42.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 0e86b4ec67e1d44367c6f8418e43050bb861094e
+      sha: 231332f4334dcdcfff8164ab8f70632bc0370c94
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **master**

### gate-armory Image Version

armory/gate-armory:2025.01.29.03.02.42.master

### Service VCS

[231332f4334dcdcfff8164ab8f70632bc0370c94](https://github.com/armory-io/gate-armory/commit/231332f4334dcdcfff8164ab8f70632bc0370c94)

### Base Service VCS

[0ce16ba04d4315ec722eb60328a6d8b32af8b786](https://github.com/spinnaker/gate/commit/0ce16ba04d4315ec722eb60328a6d8b32af8b786)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "0ce16ba04d4315ec722eb60328a6d8b32af8b786"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:bd30a14ec89b121ee07df16b3a68368d9b7a0b0c87e88def9470a78e4e85c8c3",
        "repository": "armory/gate-armory",
        "tag": "2025.01.29.03.02.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "231332f4334dcdcfff8164ab8f70632bc0370c94"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "0ce16ba04d4315ec722eb60328a6d8b32af8b786"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:bd30a14ec89b121ee07df16b3a68368d9b7a0b0c87e88def9470a78e4e85c8c3",
        "repository": "armory/gate-armory",
        "tag": "2025.01.29.03.02.42.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "231332f4334dcdcfff8164ab8f70632bc0370c94"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```