### PR TITLE
chore(cd): update clouddriver-armory version to 2025.02.11.22.41.15.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:54ada81dda0cce072d787987491ef122c5a4f50f05fb69e86be347cdd9fa2e2c
+      imageId: sha256:33e21ddbb76877a0234d2ea913a39966fc4325cd25b517fd409669637e48b21b
       repository: armory/clouddriver-armory
-      tag: 2024.09.25.16.25.02.master
+      tag: 2025.02.11.22.41.15.master
     vcs:
       repo:
         orgName: armory-io
         repoName: clouddriver-armory
         type: github
-      sha: d747d16bc1cee5c60a794caafbf4facbcb27a9e6
+      sha: 69fe2f284833e35e471a461cf898c2f3e23da628
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **master**

### clouddriver-armory Image Version

armory/clouddriver-armory:2025.02.11.22.41.15.master

### Service VCS

[69fe2f284833e35e471a461cf898c2f3e23da628](https://github.com/armory-io/clouddriver-armory/commit/69fe2f284833e35e471a461cf898c2f3e23da628)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:33e21ddbb76877a0234d2ea913a39966fc4325cd25b517fd409669637e48b21b",
        "repository": "armory/clouddriver-armory",
        "tag": "2025.02.11.22.41.15.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "69fe2f284833e35e471a461cf898c2f3e23da628"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:33e21ddbb76877a0234d2ea913a39966fc4325cd25b517fd409669637e48b21b",
        "repository": "armory/clouddriver-armory",
        "tag": "2025.02.11.22.41.15.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "clouddriver-armory",
          "type": "github"
        },
        "sha": "69fe2f284833e35e471a461cf898c2f3e23da628"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```