### PR TITLE
chore(cd): update gate-armory version to 2025.02.13.00.13.59.master

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:2bcf73512affabcbdf99880c544d57889c2540a29d179812c0df72d34720f622
+      imageId: sha256:26741c080bdab7c4463dd8308b3b2882b1adfdce0b6b3392c3868cf277e0a507
       repository: armory/gate-armory
-      tag: 2024.09.19.19.19.59.master
+      tag: 2025.02.13.00.13.59.master
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 0e86b4ec67e1d44367c6f8418e43050bb861094e
+      sha: 7b0bac6e6dbf10ababf5034f326a28b7aba50c09
   igor-armory:
     baseService: igor
     image:

--- a/stack.yml
+++ b/stack.yml
@@ -2,9 +2,9 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:54ada81dda0cce072d787987491ef122c5a4f50f05fb69e86be347cdd9fa2e2c
+      imageId: sha256:19569c6251dbf2993e7d1d847b9067531827b2ccd3896ad788302ee1e3902ca9
       repository: armory/clouddriver-armory
-      tag: 2024.09.25.16.25.02.master
+      tag: 2025.03.13.21.12.20.master
     vcs:
       repo:
         orgName: armory-io


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **master**

### gate-armory Image Version

armory/gate-armory:2025.02.13.00.13.59.master

### Service VCS

[7b0bac6e6dbf10ababf5034f326a28b7aba50c09](https://github.com/armory-io/gate-armory/commit/7b0bac6e6dbf10ababf5034f326a28b7aba50c09)

### Base Service VCS

[f4b8602641142ef4953c96a68509ed51bdd2875b](https://github.com/spinnaker/gate/commit/f4b8602641142ef4953c96a68509ed51bdd2875b)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "f4b8602641142ef4953c96a68509ed51bdd2875b"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:26741c080bdab7c4463dd8308b3b2882b1adfdce0b6b3392c3868cf277e0a507",
        "repository": "armory/gate-armory",
        "tag": "2025.02.13.00.13.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "7b0bac6e6dbf10ababf5034f326a28b7aba50c09"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "f4b8602641142ef4953c96a68509ed51bdd2875b"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:26741c080bdab7c4463dd8308b3b2882b1adfdce0b6b3392c3868cf277e0a507",
        "repository": "armory/gate-armory",
        "tag": "2025.02.13.00.13.59.master"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "7b0bac6e6dbf10ababf5034f326a28b7aba50c09"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```