### PR TITLE
chore(cd): update gate-armory version to 2025.03.24.11.44.17.release-2.37.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -73,15 +73,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:2bcf73512affabcbdf99880c544d57889c2540a29d179812c0df72d34720f622
+      imageId: sha256:9d4a1dc53854a17f8f75075ed3ebf09f0a5ed01d45264b625d786bde99a180c7
       repository: armory/gate-armory
-      tag: 2024.09.19.19.19.59.master
+      tag: 2025.03.24.11.44.17.release-2.37.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: 0e86b4ec67e1d44367c6f8418e43050bb861094e
+      sha: 0ad07dfef0d038a883e3b785a674d6bd56a9defe
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.37.x**

### gate-armory Image Version

armory/gate-armory:2025.03.24.11.44.17.release-2.37.x

### Service VCS

[0ad07dfef0d038a883e3b785a674d6bd56a9defe](https://github.com/armory-io/gate-armory/commit/0ad07dfef0d038a883e3b785a674d6bd56a9defe)

### Base Service VCS

[](https://github.com///commit/)

Event Payload
```
{
  "branch": "release-2.37.x",
  "service": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:9d4a1dc53854a17f8f75075ed3ebf09f0a5ed01d45264b625d786bde99a180c7",
        "repository": "armory/gate-armory",
        "tag": "2025.03.24.11.44.17.release-2.37.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "0ad07dfef0d038a883e3b785a674d6bd56a9defe"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": null,
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:9d4a1dc53854a17f8f75075ed3ebf09f0a5ed01d45264b625d786bde99a180c7",
        "repository": "armory/gate-armory",
        "tag": "2025.03.24.11.44.17.release-2.37.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "0ad07dfef0d038a883e3b785a674d6bd56a9defe"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```