### PR TITLE
chore(cd): update clouddriver-armory version to 2025.09.18.16.38.26.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:53c8c982685cd6a80c135bffd77194626c5ddbe36bdc8a06125c7ad894862910
+      imageId: sha256:3482273585c84fa1f581669aefbdc2ce709a48e02c899d6b3db29a98a59ec90d
       repository: armory/clouddriver-armory
-      tag: 2025.04.23.07.44.02.master
+      tag: 2025.09.18.16.38.26.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: clouddriver-armory
+        repoName: armory-extensions
         type: github
-      sha: 16adca86ee19211b3251fa86fc32da0a82c0b141
+      sha: dc41b0e377d7d5ae57819844754a9ac7958a872b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.38.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2025.09.18.16.38.26.release-2.38.x

### Service VCS

[dc41b0e377d7d5ae57819844754a9ac7958a872b](https://github.com/armory-io/armory-extensions/commit/dc41b0e377d7d5ae57819844754a9ac7958a872b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3482273585c84fa1f581669aefbdc2ce709a48e02c899d6b3db29a98a59ec90d",
        "repository": "armory/clouddriver-armory",
        "tag": "2025.09.18.16.38.26.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "dc41b0e377d7d5ae57819844754a9ac7958a872b"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3482273585c84fa1f581669aefbdc2ce709a48e02c899d6b3db29a98a59ec90d",
        "repository": "armory/clouddriver-armory",
        "tag": "2025.09.18.16.38.26.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "dc41b0e377d7d5ae57819844754a9ac7958a872b"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```