### PR TITLE
chore(cd): update deck-armory version to 2025.09.22.10.29.53.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:3c940a6c3fabcc43be24e1144f6b20c3cddeaffddf288fced0b0af8b1afacd0e
+      imageId: sha256:3fc1c3c1078fe5e761c71c13493dae3bb144f1fb0d324fbc202b6f835cb2ef22
       repository: armory/deck-armory
-      tag: 2025.08.20.02.33.17.main
+      tag: 2025.09.22.10.29.53.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: babaa4704f1df8a6f6b42e533716396c8a0f529b
+      sha: 7319cc05250f83a534d66d2f376a0c4ef3f83a3b
   dinghy:
     baseService: dinghy
     image:


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.38.x**

### deck-armory Image Version

armory/deck-armory:2025.09.22.10.29.53.release-2.38.x

### Service VCS

[7319cc05250f83a534d66d2f376a0c4ef3f83a3b](https://github.com/armory-io/armory-extensions/commit/7319cc05250f83a534d66d2f376a0c4ef3f83a3b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3fc1c3c1078fe5e761c71c13493dae3bb144f1fb0d324fbc202b6f835cb2ef22",
        "repository": "armory/deck-armory",
        "tag": "2025.09.22.10.29.53.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "7319cc05250f83a534d66d2f376a0c4ef3f83a3b"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:3fc1c3c1078fe5e761c71c13493dae3bb144f1fb0d324fbc202b6f835cb2ef22",
        "repository": "armory/deck-armory",
        "tag": "2025.09.22.10.29.53.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "7319cc05250f83a534d66d2f376a0c4ef3f83a3b"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```