### PR TITLE
chore(cd): update gate-armory version to 2025.09.22.10.59.01.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:872bd5a1d1782a0d161da3a557f5ef07e7ead8254f0f7cdf873f59ee50a2d5f4
+      imageId: sha256:7bd5f1e479a29a60f6e4b01f24ec7dcc30b6225d16755c18ed374f99843dc55e
       repository: armory/gate-armory
-      tag: 2025.09.18.16.38.26.release-2.38.x
+      tag: 2025.09.22.10.59.01.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: dc41b0e377d7d5ae57819844754a9ac7958a872b
+      sha: 38674564507f098690276af581add0f96b244ba1
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.38.x**

### gate-armory Image Version

armory/gate-armory:2025.09.22.10.59.01.release-2.38.x

### Service VCS

[38674564507f098690276af581add0f96b244ba1](https://github.com/armory-io/armory-extensions/commit/38674564507f098690276af581add0f96b244ba1)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:7bd5f1e479a29a60f6e4b01f24ec7dcc30b6225d16755c18ed374f99843dc55e",
        "repository": "armory/gate-armory",
        "tag": "2025.09.22.10.59.01.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "38674564507f098690276af581add0f96b244ba1"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:7bd5f1e479a29a60f6e4b01f24ec7dcc30b6225d16755c18ed374f99843dc55e",
        "repository": "armory/gate-armory",
        "tag": "2025.09.22.10.59.01.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "38674564507f098690276af581add0f96b244ba1"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```