### PR TITLE
chore(cd): update front50-armory version to 2025.09.22.12.26.04.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:3d6b046dbaee13abcd173517d2f548f53b2596b178bf9cb7042af397a143a341
+      imageId: sha256:c5074eb42d1408a66f572f8810d5e3acf7619285d1cf2669d0fd4a11d269c047
       repository: armory/front50-armory
-      tag: 2025.04.23.07.47.09.master
+      tag: 2025.09.22.12.26.04.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: front50-armory
+        repoName: armory-extensions
         type: github
-      sha: 0e8e367a38e116f2a13a7681411b297d9b5792ad
+      sha: 2f60f427e4f2edaf6eba815fce76fbac74a0b080
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.38.x**

### front50-armory Image Version

armory/front50-armory:2025.09.22.12.26.04.release-2.38.x

### Service VCS

[2f60f427e4f2edaf6eba815fce76fbac74a0b080](https://github.com/armory-io/armory-extensions/commit/2f60f427e4f2edaf6eba815fce76fbac74a0b080)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c5074eb42d1408a66f572f8810d5e3acf7619285d1cf2669d0fd4a11d269c047",
        "repository": "armory/front50-armory",
        "tag": "2025.09.22.12.26.04.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "2f60f427e4f2edaf6eba815fce76fbac74a0b080"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c5074eb42d1408a66f572f8810d5e3acf7619285d1cf2669d0fd4a11d269c047",
        "repository": "armory/front50-armory",
        "tag": "2025.09.22.12.26.04.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "2f60f427e4f2edaf6eba815fce76fbac74a0b080"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```