### PR TITLE
chore(cd): update front50-armory version to 2025.09.24.11.46.24.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:3d6b046dbaee13abcd173517d2f548f53b2596b178bf9cb7042af397a143a341
+      imageId: sha256:c257c2f9dc69dc186dc6ac00bb505a3e0b33c14530061ada8c73004a28335293
       repository: armory/front50-armory
-      tag: 2025.04.23.07.47.09.master
+      tag: 2025.09.24.11.46.24.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
-        repoName: front50-armory
+        repoName: armory-extensions
         type: github
-      sha: 0e8e367a38e116f2a13a7681411b297d9b5792ad
+      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.38.x**

### front50-armory Image Version

armory/front50-armory:2025.09.24.11.46.24.release-2.38.x

### Service VCS

[ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31](https://github.com/armory-io/armory-extensions/commit/ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c257c2f9dc69dc186dc6ac00bb505a3e0b33c14530061ada8c73004a28335293",
        "repository": "armory/front50-armory",
        "tag": "2025.09.24.11.46.24.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:c257c2f9dc69dc186dc6ac00bb505a3e0b33c14530061ada8c73004a28335293",
        "repository": "armory/front50-armory",
        "tag": "2025.09.24.11.46.24.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```