### PR TITLE
chore(cd): update front50-armory version to 2025.09.30.17.00.59.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:b7544ea18a27fd8a7ac89dbc8364781cf8de0a6971fb9e4a9f701327f1a3ccbe
+      imageId: sha256:2475086e9aa5a9393f30857b7c2fd1e8b446a08206d8f1970680e1c955ca6e98
       repository: armory/front50-armory
-      tag: 2025.09.24.11.46.24.release-2.38.x
+      tag: 2025.09.30.17.00.59.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
+      sha: 385a762f6b5b6b6b97d66a2580a717a5bdc84e89
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.38.x**

### front50-armory Image Version

armory/front50-armory:2025.09.30.17.00.59.release-2.38.x

### Service VCS

[385a762f6b5b6b6b97d66a2580a717a5bdc84e89](https://github.com/armory-io/armory-extensions/commit/385a762f6b5b6b6b97d66a2580a717a5bdc84e89)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:2475086e9aa5a9393f30857b7c2fd1e8b446a08206d8f1970680e1c955ca6e98",
        "repository": "armory/front50-armory",
        "tag": "2025.09.30.17.00.59.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "385a762f6b5b6b6b97d66a2580a717a5bdc84e89"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:2475086e9aa5a9393f30857b7c2fd1e8b446a08206d8f1970680e1c955ca6e98",
        "repository": "armory/front50-armory",
        "tag": "2025.09.30.17.00.59.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "385a762f6b5b6b6b97d66a2580a717a5bdc84e89"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```