### PR TITLE
chore(cd): update front50-armory version to 2025.10.01.02.57.52.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:3d6b046dbaee13abcd173517d2f548f53b2596b178bf9cb7042af397a143a341
+      imageId: sha256:d097c07a45bd35150c5f4f59facfc904e563ae6431c102e0d1d0f3b52e33e4e7
       repository: armory/front50-armory
-      tag: 2025.04.23.07.47.09.master
+      tag: 2025.10.01.02.57.52.main
     vcs:
       repo:
         orgName: armory-io
-        repoName: front50-armory
+        repoName: armory-extensions
         type: github
-      sha: 0e8e367a38e116f2a13a7681411b297d9b5792ad
+      sha: d6b098ecf4362faca3d51572c7c8b7d8a47670d7
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **master**

### front50-armory Image Version

armory/front50-armory:2025.10.01.02.57.52.main

### Service VCS

[d6b098ecf4362faca3d51572c7c8b7d8a47670d7](https://github.com/armory-io/armory-extensions/commit/d6b098ecf4362faca3d51572c7c8b7d8a47670d7)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:d097c07a45bd35150c5f4f59facfc904e563ae6431c102e0d1d0f3b52e33e4e7",
        "repository": "armory/front50-armory",
        "tag": "2025.10.01.02.57.52.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "d6b098ecf4362faca3d51572c7c8b7d8a47670d7"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:d097c07a45bd35150c5f4f59facfc904e563ae6431c102e0d1d0f3b52e33e4e7",
        "repository": "armory/front50-armory",
        "tag": "2025.10.01.02.57.52.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "d6b098ecf4362faca3d51572c7c8b7d8a47670d7"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```