### PR TITLE
chore(cd): update clouddriver-armory version to 2025.10.01.02.57.52.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:53c8c982685cd6a80c135bffd77194626c5ddbe36bdc8a06125c7ad894862910
+      imageId: sha256:42e0f8985c0c2fd02ee90b15e1661e4d96517e5b94529ae3709eb39e5b3ab076
       repository: armory/clouddriver-armory
-      tag: 2025.04.23.07.44.02.master
+      tag: 2025.10.01.02.57.52.main
     vcs:
       repo:
         orgName: armory-io
-        repoName: clouddriver-armory
+        repoName: armory-extensions
         type: github
-      sha: 16adca86ee19211b3251fa86fc32da0a82c0b141
+      sha: d6b098ecf4362faca3d51572c7c8b7d8a47670d7
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **master**

### clouddriver-armory Image Version

armory/clouddriver-armory:2025.10.01.02.57.52.main

### Service VCS

[d6b098ecf4362faca3d51572c7c8b7d8a47670d7](https://github.com/armory-io/armory-extensions/commit/d6b098ecf4362faca3d51572c7c8b7d8a47670d7)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:42e0f8985c0c2fd02ee90b15e1661e4d96517e5b94529ae3709eb39e5b3ab076",
        "repository": "armory/clouddriver-armory",
        "tag": "2025.10.01.02.57.52.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "d6b098ecf4362faca3d51572c7c8b7d8a47670d7"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:42e0f8985c0c2fd02ee90b15e1661e4d96517e5b94529ae3709eb39e5b3ab076",
        "repository": "armory/clouddriver-armory",
        "tag": "2025.10.01.02.57.52.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "d6b098ecf4362faca3d51572c7c8b7d8a47670d7"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```