### PR TITLE
chore(cd): update gate-armory version to 2025.10.01.03.26.39.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:3942e67dde265b3c140edffd165d108c52709eaa8a57a3d7995c7ffb7c910207
+      imageId: sha256:2344c066c6648ad6c70d9405f8dff3995a05c810ee89887b66eddeab09cf0bc9
       repository: armory/gate-armory
-      tag: 2025.09.24.11.46.24.release-2.38.x
+      tag: 2025.10.01.03.26.39.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
+      sha: 297b6b01423fd190cd4a02258f1abe2cb4173736
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.38.x**

### gate-armory Image Version

armory/gate-armory:2025.10.01.03.26.39.release-2.38.x

### Service VCS

[297b6b01423fd190cd4a02258f1abe2cb4173736](https://github.com/armory-io/armory-extensions/commit/297b6b01423fd190cd4a02258f1abe2cb4173736)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:2344c066c6648ad6c70d9405f8dff3995a05c810ee89887b66eddeab09cf0bc9",
        "repository": "armory/gate-armory",
        "tag": "2025.10.01.03.26.39.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "297b6b01423fd190cd4a02258f1abe2cb4173736"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:2344c066c6648ad6c70d9405f8dff3995a05c810ee89887b66eddeab09cf0bc9",
        "repository": "armory/gate-armory",
        "tag": "2025.10.01.03.26.39.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "297b6b01423fd190cd4a02258f1abe2cb4173736"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```