### PR TITLE
chore(cd): update front50-armory version to 2025.10.01.03.35.45.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:b7544ea18a27fd8a7ac89dbc8364781cf8de0a6971fb9e4a9f701327f1a3ccbe
+      imageId: sha256:dca2b0783551801d9a642f76c1c758ccab2cb479b9ff27c64b61f99ed01bfb37
       repository: armory/front50-armory
-      tag: 2025.09.24.11.46.24.release-2.38.x
+      tag: 2025.10.01.03.35.45.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
+      sha: 4ce84ef3b342d9d8a181283b6f306b677fa0f403
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.38.x**

### front50-armory Image Version

armory/front50-armory:2025.10.01.03.35.45.release-2.38.x

### Service VCS

[4ce84ef3b342d9d8a181283b6f306b677fa0f403](https://github.com/armory-io/armory-extensions/commit/4ce84ef3b342d9d8a181283b6f306b677fa0f403)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:dca2b0783551801d9a642f76c1c758ccab2cb479b9ff27c64b61f99ed01bfb37",
        "repository": "armory/front50-armory",
        "tag": "2025.10.01.03.35.45.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "4ce84ef3b342d9d8a181283b6f306b677fa0f403"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:dca2b0783551801d9a642f76c1c758ccab2cb479b9ff27c64b61f99ed01bfb37",
        "repository": "armory/front50-armory",
        "tag": "2025.10.01.03.35.45.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "4ce84ef3b342d9d8a181283b6f306b677fa0f403"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```