### PR TITLE
chore(cd): update gate-armory version to 2025.10.01.03.35.45.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:3942e67dde265b3c140edffd165d108c52709eaa8a57a3d7995c7ffb7c910207
+      imageId: sha256:bcbfd7e0cf0f6c86341fcd821a90f29af5ec02f3e76001421a62c6338b0f1843
       repository: armory/gate-armory
-      tag: 2025.09.24.11.46.24.release-2.38.x
+      tag: 2025.10.01.03.35.45.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
+      sha: 4ce84ef3b342d9d8a181283b6f306b677fa0f403
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.38.x**

### gate-armory Image Version

armory/gate-armory:2025.10.01.03.35.45.release-2.38.x

### Service VCS

[4ce84ef3b342d9d8a181283b6f306b677fa0f403](https://github.com/armory-io/armory-extensions/commit/4ce84ef3b342d9d8a181283b6f306b677fa0f403)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:bcbfd7e0cf0f6c86341fcd821a90f29af5ec02f3e76001421a62c6338b0f1843",
        "repository": "armory/gate-armory",
        "tag": "2025.10.01.03.35.45.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "4ce84ef3b342d9d8a181283b6f306b677fa0f403"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:bcbfd7e0cf0f6c86341fcd821a90f29af5ec02f3e76001421a62c6338b0f1843",
        "repository": "armory/gate-armory",
        "tag": "2025.10.01.03.35.45.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "4ce84ef3b342d9d8a181283b6f306b677fa0f403"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```