### PR TITLE
chore(cd): update deck-armory version to 2025.10.01.03.35.45.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:9a858420ff7a368e9b0b66c2d0d35e81f8c78cefa63404c8df4c686dd6a1e13f
+      imageId: sha256:b2ce57c538714ad518dc6f3893a1bae27d270629182c5923c8d5ef17968d7f48
       repository: armory/deck-armory
-      tag: 2025.09.24.11.46.24.release-2.38.x
+      tag: 2025.10.01.03.35.45.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
+      sha: 4ce84ef3b342d9d8a181283b6f306b677fa0f403
   dinghy:
     baseService: dinghy
     image:


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.38.x**

### deck-armory Image Version

armory/deck-armory:2025.10.01.03.35.45.release-2.38.x

### Service VCS

[4ce84ef3b342d9d8a181283b6f306b677fa0f403](https://github.com/armory-io/armory-extensions/commit/4ce84ef3b342d9d8a181283b6f306b677fa0f403)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:b2ce57c538714ad518dc6f3893a1bae27d270629182c5923c8d5ef17968d7f48",
        "repository": "armory/deck-armory",
        "tag": "2025.10.01.03.35.45.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "4ce84ef3b342d9d8a181283b6f306b677fa0f403"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:b2ce57c538714ad518dc6f3893a1bae27d270629182c5923c8d5ef17968d7f48",
        "repository": "armory/deck-armory",
        "tag": "2025.10.01.03.35.45.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "4ce84ef3b342d9d8a181283b6f306b677fa0f403"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```