### PR TITLE
chore(cd): update terraformer version to 2025.10.01.03.28.08.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:e079006d64776ff993882463fd1950a1281647995d3bc30aed2c1d532e3621b8
+      imageId: sha256:2a6ea73a9fd150f4fbb4e61025663c15ad75ad063110f49f8c0be8051155aa71
       repository: armory/terraformer
-      tag: 2025.08.20.02.33.17.main
+      tag: 2025.10.01.03.28.08.main
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: babaa4704f1df8a6f6b42e533716396c8a0f529b
+      sha: 9b96eaed592a787e28be9200b1691ca19a443146


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **master**

### terraformer Image Version

armory/terraformer:2025.10.01.03.28.08.main

### Service VCS

[9b96eaed592a787e28be9200b1691ca19a443146](https://github.com/armory-io/armory-extensions/commit/9b96eaed592a787e28be9200b1691ca19a443146)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:2a6ea73a9fd150f4fbb4e61025663c15ad75ad063110f49f8c0be8051155aa71",
        "repository": "armory/terraformer",
        "tag": "2025.10.01.03.28.08.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9b96eaed592a787e28be9200b1691ca19a443146"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:2a6ea73a9fd150f4fbb4e61025663c15ad75ad063110f49f8c0be8051155aa71",
        "repository": "armory/terraformer",
        "tag": "2025.10.01.03.28.08.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9b96eaed592a787e28be9200b1691ca19a443146"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```