### PR TITLE
chore(cd): update deck-armory version to 2025.10.06.22.12.32.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:9a858420ff7a368e9b0b66c2d0d35e81f8c78cefa63404c8df4c686dd6a1e13f
+      imageId: sha256:ac10eacfcfb594314f9337f08e84e726cce01d61a80fd8a97aa1eb4fb9f25c7a
       repository: armory/deck-armory
-      tag: 2025.09.24.11.46.24.release-2.38.x
+      tag: 2025.10.06.22.12.32.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ecb4f105b01162bd2a10e6ef63bf1a568e4a4b31
+      sha: 6c5482eaede212118c6f44f38d377765bab1aa5b
   dinghy:
     baseService: dinghy
     image:


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.38.x**

### deck-armory Image Version

armory/deck-armory:2025.10.06.22.12.32.release-2.38.x

### Service VCS

[6c5482eaede212118c6f44f38d377765bab1aa5b](https://github.com/armory-io/armory-extensions/commit/6c5482eaede212118c6f44f38d377765bab1aa5b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:ac10eacfcfb594314f9337f08e84e726cce01d61a80fd8a97aa1eb4fb9f25c7a",
        "repository": "armory/deck-armory",
        "tag": "2025.10.06.22.12.32.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "6c5482eaede212118c6f44f38d377765bab1aa5b"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:ac10eacfcfb594314f9337f08e84e726cce01d61a80fd8a97aa1eb4fb9f25c7a",
        "repository": "armory/deck-armory",
        "tag": "2025.10.06.22.12.32.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "6c5482eaede212118c6f44f38d377765bab1aa5b"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```