### PR TITLE
chore(cd): update gate-armory version to 2026.04.14.21.15.34.release-2.36.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:8bcd5744168902ad6ccba82e1534086ca6fde89efec442b84c84bfe578d32e0d
+      imageId: sha256:efc0c3d1c41b59e7ff304fadce497295970dfa8a176a07c06d7790b2f68ea64b
       repository: armory/gate-armory
-      tag: 2026.01.12.12.41.20.release-2.36.x
+      tag: 2026.04.14.21.15.34.release-2.36.x
     vcs:
       repo:
         orgName: armory-io
         repoName: gate-armory
         type: github
-      sha: f99a459232f70e19a719a1962f7c6fcee9218750
+      sha: 433a62368b2a1884ab4cc4e79a41a9b6b8b352c3
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.36.x**

### gate-armory Image Version

armory/gate-armory:2026.04.14.21.15.34.release-2.36.x

### Service VCS

[433a62368b2a1884ab4cc4e79a41a9b6b8b352c3](https://github.com/armory-io/gate-armory/commit/433a62368b2a1884ab4cc4e79a41a9b6b8b352c3)

### Base Service VCS

[938d70ebbeb52e9160f0f557bd422e726dd2896f](https://github.com/spinnaker/gate/commit/938d70ebbeb52e9160f0f557bd422e726dd2896f)

Event Payload
```
{
  "branch": "release-2.36.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "938d70ebbeb52e9160f0f557bd422e726dd2896f"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:efc0c3d1c41b59e7ff304fadce497295970dfa8a176a07c06d7790b2f68ea64b",
        "repository": "armory/gate-armory",
        "tag": "2026.04.14.21.15.34.release-2.36.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "433a62368b2a1884ab4cc4e79a41a9b6b8b352c3"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "gate",
        "type": "github"
      },
      "sha": "938d70ebbeb52e9160f0f557bd422e726dd2896f"
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:efc0c3d1c41b59e7ff304fadce497295970dfa8a176a07c06d7790b2f68ea64b",
        "repository": "armory/gate-armory",
        "tag": "2026.04.14.21.15.34.release-2.36.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "gate-armory",
          "type": "github"
        },
        "sha": "433a62368b2a1884ab4cc4e79a41a9b6b8b352c3"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```