### PR TITLE
chore(cd): update fiat-armory version to 2026.04.24.21.37.17.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:ca1ae6165520ab6d497b286fd7b075317a7fe949fb9747c97345787bf71366d6
+      imageId: sha256:05f3d551271ba9c74e8ef84e9c046f539854c97bec1910fde01fefd5125a9f72
       repository: armory/fiat-armory
-      tag: 2025.11.10.19.59.09.release-2.38.x
+      tag: 2026.04.24.21.37.17.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 582c94fdd4167bf1cf689f719c70e2c89eba3348
+      sha: 673304d0e65e9ce1a331324a69f8a52a9c5d641b
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
## Promotion Of New fiat-armory Version

### Release Branch

* **release-2.38.x**

### fiat-armory Image Version

armory/fiat-armory:2026.04.24.21.37.17.release-2.38.x

### Service VCS

[673304d0e65e9ce1a331324a69f8a52a9c5d641b](https://github.com/armory-io/armory-extensions/commit/673304d0e65e9ce1a331324a69f8a52a9c5d641b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:05f3d551271ba9c74e8ef84e9c046f539854c97bec1910fde01fefd5125a9f72",
        "repository": "armory/fiat-armory",
        "tag": "2026.04.24.21.37.17.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "673304d0e65e9ce1a331324a69f8a52a9c5d641b"
      }
    },
    "name": "fiat-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:05f3d551271ba9c74e8ef84e9c046f539854c97bec1910fde01fefd5125a9f72",
        "repository": "armory/fiat-armory",
        "tag": "2026.04.24.21.37.17.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "673304d0e65e9ce1a331324a69f8a52a9c5d641b"
      }
    },
    "name": "fiat-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```