### PR TITLE
chore(cd): update rosco-armory version to 2026.04.24.21.37.17.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -122,15 +122,15 @@ services:
   rosco-armory:
     baseService: rosco
     image:
-      imageId: sha256:4dd62c8e7006c9b7deb63c4c0ba04b622ecb0c7a7db5f4129bfddd524ce6df95
+      imageId: sha256:86af18333ca1438622f274d0e4f3294f6b1f8861a0b5391bb28f785f110575e6
       repository: armory/rosco-armory
-      tag: 2025.11.10.19.59.09.release-2.38.x
+      tag: 2026.04.24.21.37.17.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 582c94fdd4167bf1cf689f719c70e2c89eba3348
+      sha: 673304d0e65e9ce1a331324a69f8a52a9c5d641b
   terraformer:
     baseService: terraformer
     image:


### PR DESCRIPTION
## Promotion Of New rosco-armory Version

### Release Branch

* **release-2.38.x**

### rosco-armory Image Version

armory/rosco-armory:2026.04.24.21.37.17.release-2.38.x

### Service VCS

[673304d0e65e9ce1a331324a69f8a52a9c5d641b](https://github.com/armory-io/armory-extensions/commit/673304d0e65e9ce1a331324a69f8a52a9c5d641b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:86af18333ca1438622f274d0e4f3294f6b1f8861a0b5391bb28f785f110575e6",
        "repository": "armory/rosco-armory",
        "tag": "2026.04.24.21.37.17.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "673304d0e65e9ce1a331324a69f8a52a9c5d641b"
      }
    },
    "name": "rosco-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "rosco",
      "image": {
        "imageId": "sha256:86af18333ca1438622f274d0e4f3294f6b1f8861a0b5391bb28f785f110575e6",
        "repository": "armory/rosco-armory",
        "tag": "2026.04.24.21.37.17.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "673304d0e65e9ce1a331324a69f8a52a9c5d641b"
      }
    },
    "name": "rosco-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```