### PR TITLE
chore(cd): update clouddriver-armory version to 2026.04.24.21.37.17.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:9cc673f4726313c999a4fb673a0216579f8cba1a20a0351d2bd7921ac0457ea0
+      imageId: sha256:1b9fa5c84ee819c2b5ef68f4433a15e49f9edb45ad58f166c0aa919e1031c779
       repository: armory/clouddriver-armory
-      tag: 2025.11.10.19.59.09.release-2.38.x
+      tag: 2026.04.24.21.37.17.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 582c94fdd4167bf1cf689f719c70e2c89eba3348
+      sha: 673304d0e65e9ce1a331324a69f8a52a9c5d641b
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.38.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.04.24.21.37.17.release-2.38.x

### Service VCS

[673304d0e65e9ce1a331324a69f8a52a9c5d641b](https://github.com/armory-io/armory-extensions/commit/673304d0e65e9ce1a331324a69f8a52a9c5d641b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1b9fa5c84ee819c2b5ef68f4433a15e49f9edb45ad58f166c0aa919e1031c779",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.04.24.21.37.17.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "673304d0e65e9ce1a331324a69f8a52a9c5d641b"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:1b9fa5c84ee819c2b5ef68f4433a15e49f9edb45ad58f166c0aa919e1031c779",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.04.24.21.37.17.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "673304d0e65e9ce1a331324a69f8a52a9c5d641b"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```