### PR TITLE
chore(cd): update front50-armory version to 2026.04.27.14.12.38.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:6cd7ab2b78e2cb4b8de39ade50f1b50630aa139a9ecf7d12b8c6f04b60bc7250
+      imageId: sha256:3b44eb13b373ec45edd70cdad6279d2b0e59f25e37464d83111cfe8e8dfeb9fb
       repository: armory/front50-armory
-      tag: 2025.11.10.19.59.09.release-2.38.x
+      tag: 2026.04.27.14.12.38.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 582c94fdd4167bf1cf689f719c70e2c89eba3348
+      sha: 365a84692f4859d7f571211961d5b118084b822b
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.38.x**

### front50-armory Image Version

armory/front50-armory:2026.04.27.14.12.38.release-2.38.x

### Service VCS

[365a84692f4859d7f571211961d5b118084b822b](https://github.com/armory-io/armory-extensions/commit/365a84692f4859d7f571211961d5b118084b822b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:3b44eb13b373ec45edd70cdad6279d2b0e59f25e37464d83111cfe8e8dfeb9fb",
        "repository": "armory/front50-armory",
        "tag": "2026.04.27.14.12.38.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "365a84692f4859d7f571211961d5b118084b822b"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:3b44eb13b373ec45edd70cdad6279d2b0e59f25e37464d83111cfe8e8dfeb9fb",
        "repository": "armory/front50-armory",
        "tag": "2026.04.27.14.12.38.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "365a84692f4859d7f571211961d5b118084b822b"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```