### PR TITLE
chore(cd): update deck-armory version to 2026.04.27.14.12.38.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:4ec30f1f908b43a0a8d5b90f61b15f1883f838cfe680f23698b45524163b83e9
+      imageId: sha256:bab07f6485cf3db91767a60744af396d9cfbdb6aff4019ba45dba8f7d3c6f453
       repository: armory/deck-armory
-      tag: 2025.11.10.19.59.09.release-2.38.x
+      tag: 2026.04.27.14.12.38.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 582c94fdd4167bf1cf689f719c70e2c89eba3348
+      sha: 365a84692f4859d7f571211961d5b118084b822b
   dinghy:
     baseService: dinghy
     image:


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.38.x**

### deck-armory Image Version

armory/deck-armory:2026.04.27.14.12.38.release-2.38.x

### Service VCS

[365a84692f4859d7f571211961d5b118084b822b](https://github.com/armory-io/armory-extensions/commit/365a84692f4859d7f571211961d5b118084b822b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:bab07f6485cf3db91767a60744af396d9cfbdb6aff4019ba45dba8f7d3c6f453",
        "repository": "armory/deck-armory",
        "tag": "2026.04.27.14.12.38.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "365a84692f4859d7f571211961d5b118084b822b"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:bab07f6485cf3db91767a60744af396d9cfbdb6aff4019ba45dba8f7d3c6f453",
        "repository": "armory/deck-armory",
        "tag": "2026.04.27.14.12.38.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "365a84692f4859d7f571211961d5b118084b822b"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```