### PR TITLE
chore(cd): update deck-armory version to 2026.06.15.10.30.01.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -14,15 +14,15 @@ services:
   deck-armory:
     baseService: deck
     image:
-      imageId: sha256:bab07f6485cf3db91767a60744af396d9cfbdb6aff4019ba45dba8f7d3c6f453
+      imageId: sha256:8d7d0f9e8cf2bdf7ca842f4ce910effe717d18a8d2d8a02d622e803742c8a789
       repository: armory/deck-armory
-      tag: 2026.04.27.14.12.38.release-2.38.x
+      tag: 2026.06.15.10.30.01.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 365a84692f4859d7f571211961d5b118084b822b
+      sha: 0e3f5224207ac8c558c254d8c1aa26001f6c2afb
   dinghy:
     baseService: dinghy
     image:


### PR DESCRIPTION
## Promotion Of New deck-armory Version

### Release Branch

* **release-2.38.x**

### deck-armory Image Version

armory/deck-armory:2026.06.15.10.30.01.release-2.38.x

### Service VCS

[0e3f5224207ac8c558c254d8c1aa26001f6c2afb](https://github.com/armory-io/armory-extensions/commit/0e3f5224207ac8c558c254d8c1aa26001f6c2afb)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:8d7d0f9e8cf2bdf7ca842f4ce910effe717d18a8d2d8a02d622e803742c8a789",
        "repository": "armory/deck-armory",
        "tag": "2026.06.15.10.30.01.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "0e3f5224207ac8c558c254d8c1aa26001f6c2afb"
      }
    },
    "name": "deck-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "deck",
      "image": {
        "imageId": "sha256:8d7d0f9e8cf2bdf7ca842f4ce910effe717d18a8d2d8a02d622e803742c8a789",
        "repository": "armory/deck-armory",
        "tag": "2026.06.15.10.30.01.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "0e3f5224207ac8c558c254d8c1aa26001f6c2afb"
      }
    },
    "name": "deck-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```