### PR TITLE
chore(cd): update fiat-armory version to 2026.06.15.11.41.34.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -50,15 +50,15 @@ services:
   fiat-armory:
     baseService: fiat
     image:
-      imageId: sha256:772b0c34403dfbd94a7fe5fb13d6836ca5ff322ad33556f69c5d62177241a209
+      imageId: sha256:079225817907d21ad376662a4633fa42ed9caed72e4053fe0bf980094158f976
       repository: armory/fiat-armory
-      tag: 2026.04.27.14.12.38.release-2.38.x
+      tag: 2026.06.15.11.41.34.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 365a84692f4859d7f571211961d5b118084b822b
+      sha: ec8a581ff19f5e5d65cdabc357fc0558b2b6efde
   front50-armory:
     baseService: front50
     image:


### PR DESCRIPTION
## Promotion Of New fiat-armory Version

### Release Branch

* **release-2.38.x**

### fiat-armory Image Version

armory/fiat-armory:2026.06.15.11.41.34.release-2.38.x

### Service VCS

[ec8a581ff19f5e5d65cdabc357fc0558b2b6efde](https://github.com/armory-io/armory-extensions/commit/ec8a581ff19f5e5d65cdabc357fc0558b2b6efde)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:079225817907d21ad376662a4633fa42ed9caed72e4053fe0bf980094158f976",
        "repository": "armory/fiat-armory",
        "tag": "2026.06.15.11.41.34.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ec8a581ff19f5e5d65cdabc357fc0558b2b6efde"
      }
    },
    "name": "fiat-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "fiat",
      "image": {
        "imageId": "sha256:079225817907d21ad376662a4633fa42ed9caed72e4053fe0bf980094158f976",
        "repository": "armory/fiat-armory",
        "tag": "2026.06.15.11.41.34.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ec8a581ff19f5e5d65cdabc357fc0558b2b6efde"
      }
    },
    "name": "fiat-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```