### PR TITLE
chore(cd): update clouddriver-armory version to 2026.06.15.11.41.34.release-2.38.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:eae7682f218e20141e2fae25a7556145c43b70f095d936dbed85b81f7a25f988
+      imageId: sha256:0d3273b61f6029a5ba6487e52cb64f18fd0f6fb2634b2a1272deae0b4397f421
       repository: armory/clouddriver-armory
-      tag: 2026.04.27.14.12.38.release-2.38.x
+      tag: 2026.06.15.11.41.34.release-2.38.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 365a84692f4859d7f571211961d5b118084b822b
+      sha: ec8a581ff19f5e5d65cdabc357fc0558b2b6efde
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.38.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.06.15.11.41.34.release-2.38.x

### Service VCS

[ec8a581ff19f5e5d65cdabc357fc0558b2b6efde](https://github.com/armory-io/armory-extensions/commit/ec8a581ff19f5e5d65cdabc357fc0558b2b6efde)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.38.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0d3273b61f6029a5ba6487e52cb64f18fd0f6fb2634b2a1272deae0b4397f421",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.06.15.11.41.34.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ec8a581ff19f5e5d65cdabc357fc0558b2b6efde"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:0d3273b61f6029a5ba6487e52cb64f18fd0f6fb2634b2a1272deae0b4397f421",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.06.15.11.41.34.release-2.38.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ec8a581ff19f5e5d65cdabc357fc0558b2b6efde"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```