### PR TITLE
chore(cd): update front50-armory version to 2026.06.19.14.17.46.release-2.39.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:f52d094384b5158e23f16908b9cd6d74980fbd29207ca4a30f6c9e8ba79269c8
+      imageId: sha256:44070be9fc26534df29d9603dae9624288bd81c767824fa9074e792ff3c23174
       repository: armory/front50-armory
-      tag: 2026.06.15.11.41.30.release-2.39.x
+      tag: 2026.06.19.14.17.46.release-2.39.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 552adaa171f6a8f82ed03c434306add0e51b5b41
+      sha: 8f40c99bd0979c73db2c003b9dccc00dd960551b
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.39.x**

### front50-armory Image Version

armory/front50-armory:2026.06.19.14.17.46.release-2.39.x

### Service VCS

[8f40c99bd0979c73db2c003b9dccc00dd960551b](https://github.com/armory-io/armory-extensions/commit/8f40c99bd0979c73db2c003b9dccc00dd960551b)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.39.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:44070be9fc26534df29d9603dae9624288bd81c767824fa9074e792ff3c23174",
        "repository": "armory/front50-armory",
        "tag": "2026.06.19.14.17.46.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "8f40c99bd0979c73db2c003b9dccc00dd960551b"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:44070be9fc26534df29d9603dae9624288bd81c767824fa9074e792ff3c23174",
        "repository": "armory/front50-armory",
        "tag": "2026.06.19.14.17.46.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "8f40c99bd0979c73db2c003b9dccc00dd960551b"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```