### PR TITLE
chore(cd): update gate-armory version to 2026.07.03.15.33.24.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:107be58dbfe014c2192549a12ad2360951619b36896db9a27824e346f11bb6bc
+      imageId: sha256:2000133f29454902f49e47f0dda08ffd4aaf964b6c30b3852c7ab967bc52f808
       repository: armory/gate-armory
-      tag: 2026.07.03.10.36.23.release-2.40.x
+      tag: 2026.07.03.15.33.24.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6d89950c0951e97c5c9c86e93546c8cd0a54fed4
+      sha: fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.07.03.15.33.24.release-2.40.x

### Service VCS

[fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9](https://github.com/armory-io/armory-extensions/commit/fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:2000133f29454902f49e47f0dda08ffd4aaf964b6c30b3852c7ab967bc52f808",
        "repository": "armory/gate-armory",
        "tag": "2026.07.03.15.33.24.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:2000133f29454902f49e47f0dda08ffd4aaf964b6c30b3852c7ab967bc52f808",
        "repository": "armory/gate-armory",
        "tag": "2026.07.03.15.33.24.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```