### PR TITLE
chore(cd): update clouddriver-armory version to 2026.07.03.15.33.24.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:b57d6183fb18a9d7d31481c256d37b15e07b6e260ab69afcd45347a5f3ba6208
+      imageId: sha256:a483c2b736594e19be903fa3bc1d0483016c35ae99c81caae3bf68fb11945e77
       repository: armory/clouddriver-armory
-      tag: 2026.07.03.10.36.23.release-2.40.x
+      tag: 2026.07.03.15.33.24.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6d89950c0951e97c5c9c86e93546c8cd0a54fed4
+      sha: fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.40.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.07.03.15.33.24.release-2.40.x

### Service VCS

[fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9](https://github.com/armory-io/armory-extensions/commit/fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a483c2b736594e19be903fa3bc1d0483016c35ae99c81caae3bf68fb11945e77",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.03.15.33.24.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:a483c2b736594e19be903fa3bc1d0483016c35ae99c81caae3bf68fb11945e77",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.03.15.33.24.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```