### PR TITLE
chore(cd): update front50-armory version to 2026.07.06.10.59.11.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:e89a8189fac982b3b3afb0fedeeffca6bd19cd07299c5a9664aa7c144edfbed3
+      imageId: sha256:d71a07ed969d1605e0ee5d1514fe5e0a0ca6782befce7ab6dca7e3942ed37e93
       repository: armory/front50-armory
-      tag: 2026.07.03.15.33.24.release-2.40.x
+      tag: 2026.07.06.10.59.11.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9
+      sha: a72f83b465d054d5b8ef82192ccfc2c637f4c0c7
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.40.x**

### front50-armory Image Version

armory/front50-armory:2026.07.06.10.59.11.release-2.40.x

### Service VCS

[a72f83b465d054d5b8ef82192ccfc2c637f4c0c7](https://github.com/armory-io/armory-extensions/commit/a72f83b465d054d5b8ef82192ccfc2c637f4c0c7)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:d71a07ed969d1605e0ee5d1514fe5e0a0ca6782befce7ab6dca7e3942ed37e93",
        "repository": "armory/front50-armory",
        "tag": "2026.07.06.10.59.11.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a72f83b465d054d5b8ef82192ccfc2c637f4c0c7"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:d71a07ed969d1605e0ee5d1514fe5e0a0ca6782befce7ab6dca7e3942ed37e93",
        "repository": "armory/front50-armory",
        "tag": "2026.07.06.10.59.11.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a72f83b465d054d5b8ef82192ccfc2c637f4c0c7"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```