### PR TITLE
chore(cd): update gate-armory version to 2026.07.06.10.59.11.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:2000133f29454902f49e47f0dda08ffd4aaf964b6c30b3852c7ab967bc52f808
+      imageId: sha256:7143078e530b177f1bc1c41a93d11ade4dd40c39010b919f5a41d64c33a5d06f
       repository: armory/gate-armory
-      tag: 2026.07.03.15.33.24.release-2.40.x
+      tag: 2026.07.06.10.59.11.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: fdb8fcafb2cb75ec90c67ea9dd10cff17a5f11e9
+      sha: a72f83b465d054d5b8ef82192ccfc2c637f4c0c7
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.07.06.10.59.11.release-2.40.x

### Service VCS

[a72f83b465d054d5b8ef82192ccfc2c637f4c0c7](https://github.com/armory-io/armory-extensions/commit/a72f83b465d054d5b8ef82192ccfc2c637f4c0c7)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:7143078e530b177f1bc1c41a93d11ade4dd40c39010b919f5a41d64c33a5d06f",
        "repository": "armory/gate-armory",
        "tag": "2026.07.06.10.59.11.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a72f83b465d054d5b8ef82192ccfc2c637f4c0c7"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:7143078e530b177f1bc1c41a93d11ade4dd40c39010b919f5a41d64c33a5d06f",
        "repository": "armory/gate-armory",
        "tag": "2026.07.06.10.59.11.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a72f83b465d054d5b8ef82192ccfc2c637f4c0c7"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```