### PR TITLE
chore(cd): update terraformer version to 2026.07.07.13.52.09.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:e079006d64776ff993882463fd1950a1281647995d3bc30aed2c1d532e3621b8
+      imageId: sha256:95ff5fa8577293b729854b929197d7ca796d1ef5edb36e76f0c57746dcda510b
       repository: armory/terraformer
-      tag: 2025.08.20.02.33.17.main
+      tag: 2026.07.07.13.52.09.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: babaa4704f1df8a6f6b42e533716396c8a0f529b
+      sha: fee083c9481773d872dff68eb6508b46f408bda1


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.40.x**

### terraformer Image Version

armory/terraformer:2026.07.07.13.52.09.release-2.40.x

### Service VCS

[fee083c9481773d872dff68eb6508b46f408bda1](https://github.com/armory-io/armory-extensions/commit/fee083c9481773d872dff68eb6508b46f408bda1)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:95ff5fa8577293b729854b929197d7ca796d1ef5edb36e76f0c57746dcda510b",
        "repository": "armory/terraformer",
        "tag": "2026.07.07.13.52.09.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "fee083c9481773d872dff68eb6508b46f408bda1"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:95ff5fa8577293b729854b929197d7ca796d1ef5edb36e76f0c57746dcda510b",
        "repository": "armory/terraformer",
        "tag": "2026.07.07.13.52.09.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "fee083c9481773d872dff68eb6508b46f408bda1"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```