### PR TITLE
chore(cd): update gate-armory version to 2026.07.08.13.03.44.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:7143078e530b177f1bc1c41a93d11ade4dd40c39010b919f5a41d64c33a5d06f
+      imageId: sha256:3f743cfaab2a936e501de0f085a2ca1bbe46173da31e4e5916c1ef5ac62e867e
       repository: armory/gate-armory
-      tag: 2026.07.06.10.59.11.release-2.40.x
+      tag: 2026.07.08.13.03.44.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: a72f83b465d054d5b8ef82192ccfc2c637f4c0c7
+      sha: ce6888934c3fa28f727517e2bc337cd449907c0e
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.07.08.13.03.44.release-2.40.x

### Service VCS

[ce6888934c3fa28f727517e2bc337cd449907c0e](https://github.com/armory-io/armory-extensions/commit/ce6888934c3fa28f727517e2bc337cd449907c0e)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:3f743cfaab2a936e501de0f085a2ca1bbe46173da31e4e5916c1ef5ac62e867e",
        "repository": "armory/gate-armory",
        "tag": "2026.07.08.13.03.44.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ce6888934c3fa28f727517e2bc337cd449907c0e"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:3f743cfaab2a936e501de0f085a2ca1bbe46173da31e4e5916c1ef5ac62e867e",
        "repository": "armory/gate-armory",
        "tag": "2026.07.08.13.03.44.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "ce6888934c3fa28f727517e2bc337cd449907c0e"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```