### PR TITLE
chore(cd): update dinghy version to 2026.07.08.15.52.50.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -26,15 +26,15 @@ services:
   dinghy:
     baseService: dinghy
     image:
-      imageId: sha256:39f873fda5dcc903c3aba1c7c249c4307439910c228d9c383aea88be763d7ec4
+      imageId: sha256:36a000b7a00a75d94681948093c3cdcdc2b4b297de899152fcef7c5984662c5a
       repository: armory/dinghy
-      tag: 2026.07.08.13.03.44.release-2.40.x
+      tag: 2026.07.08.15.52.50.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: ce6888934c3fa28f727517e2bc337cd449907c0e
+      sha: a8410654799b038aa3a00b5d7b877a8ee822a9d3
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
## Promotion Of New dinghy Version

### Release Branch

* **release-2.40.x**

### dinghy Image Version

armory/dinghy:2026.07.08.15.52.50.release-2.40.x

### Service VCS

[a8410654799b038aa3a00b5d7b877a8ee822a9d3](https://github.com/armory-io/armory-extensions/commit/a8410654799b038aa3a00b5d7b877a8ee822a9d3)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "dinghy",
      "image": {
        "imageId": "sha256:36a000b7a00a75d94681948093c3cdcdc2b4b297de899152fcef7c5984662c5a",
        "repository": "armory/dinghy",
        "tag": "2026.07.08.15.52.50.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a8410654799b038aa3a00b5d7b877a8ee822a9d3"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "dinghy",
      "image": {
        "imageId": "sha256:36a000b7a00a75d94681948093c3cdcdc2b4b297de899152fcef7c5984662c5a",
        "repository": "armory/dinghy",
        "tag": "2026.07.08.15.52.50.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a8410654799b038aa3a00b5d7b877a8ee822a9d3"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```