### PR TITLE
chore(cd): update clouddriver-armory version to 2026.07.09.13.38.03.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:4404260dc5574738a049bce791f93078effa727c3ab7a7b9644b42342ce96836
+      imageId: sha256:6fe4fd94f274d2ec52066f34da51e623792fd39c9d55164175e7735c9c4392fc
       repository: armory/clouddriver-armory
-      tag: 2026.07.08.15.52.50.release-2.40.x
+      tag: 2026.07.09.13.38.03.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: a8410654799b038aa3a00b5d7b877a8ee822a9d3
+      sha: 5e8ceaf72160473ec087eec3261504c6d4b8d89c
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.40.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.07.09.13.38.03.release-2.40.x

### Service VCS

[5e8ceaf72160473ec087eec3261504c6d4b8d89c](https://github.com/armory-io/armory-extensions/commit/5e8ceaf72160473ec087eec3261504c6d4b8d89c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:6fe4fd94f274d2ec52066f34da51e623792fd39c9d55164175e7735c9c4392fc",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.09.13.38.03.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "5e8ceaf72160473ec087eec3261504c6d4b8d89c"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:6fe4fd94f274d2ec52066f34da51e623792fd39c9d55164175e7735c9c4392fc",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.09.13.38.03.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "5e8ceaf72160473ec087eec3261504c6d4b8d89c"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```