### PR TITLE
chore(cd): update front50-armory version to 2026.07.09.14.18.01.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:cd97c87e97fc7bd38be03730021f0f7e452ba70672fdb5cddbbe62b961995556
+      imageId: sha256:89f6b1bbb41b36db2b36bc5d267913e2c7d83ce4a1fc43f8f582a1f7fc39f242
       repository: armory/front50-armory
-      tag: 2026.07.08.15.52.50.release-2.40.x
+      tag: 2026.07.09.14.18.01.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: a8410654799b038aa3a00b5d7b877a8ee822a9d3
+      sha: 22e05659368839b6ee29ffc0d074a5351f26982c
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.40.x**

### front50-armory Image Version

armory/front50-armory:2026.07.09.14.18.01.release-2.40.x

### Service VCS

[22e05659368839b6ee29ffc0d074a5351f26982c](https://github.com/armory-io/armory-extensions/commit/22e05659368839b6ee29ffc0d074a5351f26982c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:89f6b1bbb41b36db2b36bc5d267913e2c7d83ce4a1fc43f8f582a1f7fc39f242",
        "repository": "armory/front50-armory",
        "tag": "2026.07.09.14.18.01.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "22e05659368839b6ee29ffc0d074a5351f26982c"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:89f6b1bbb41b36db2b36bc5d267913e2c7d83ce4a1fc43f8f582a1f7fc39f242",
        "repository": "armory/front50-armory",
        "tag": "2026.07.09.14.18.01.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "22e05659368839b6ee29ffc0d074a5351f26982c"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```