### PR TITLE
chore(cd): update gate-armory version to 2026.07.09.14.36.52.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:76cf036b16713dd4873f86362abe6f1e9cf6be4834c066c2ec23844fd9302934
+      imageId: sha256:9c7c762b499156702e1771f0ba3398b2fbd2713978209e99efc148b94aeede10
       repository: armory/gate-armory
-      tag: 2026.07.08.15.52.50.release-2.40.x
+      tag: 2026.07.09.14.36.52.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: a8410654799b038aa3a00b5d7b877a8ee822a9d3
+      sha: 56796307ca0faef62df0f10a0994deab5553f1a6
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.07.09.14.36.52.release-2.40.x

### Service VCS

[56796307ca0faef62df0f10a0994deab5553f1a6](https://github.com/armory-io/armory-extensions/commit/56796307ca0faef62df0f10a0994deab5553f1a6)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:9c7c762b499156702e1771f0ba3398b2fbd2713978209e99efc148b94aeede10",
        "repository": "armory/gate-armory",
        "tag": "2026.07.09.14.36.52.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "56796307ca0faef62df0f10a0994deab5553f1a6"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:9c7c762b499156702e1771f0ba3398b2fbd2713978209e99efc148b94aeede10",
        "repository": "armory/gate-armory",
        "tag": "2026.07.09.14.36.52.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "56796307ca0faef62df0f10a0994deab5553f1a6"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```