### PR TITLE
chore(cd): update terraformer version to 2026.07.13.08.57.58.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:274a4a6c760978421d615d49349648feb0a0b9e318b6cfac682741558e0c6e95
+      imageId: sha256:fdc8ca2fc7b96b89a1d39f61c550739115286ddb8a6f39433f2280d177a21e7b
       repository: armory/terraformer
-      tag: 2026.07.09.14.36.52.release-2.40.x
+      tag: 2026.07.13.08.57.58.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 56796307ca0faef62df0f10a0994deab5553f1a6
+      sha: 5316cdf53a2c78f78c116ff478012d58f9974e27


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.40.x**

### terraformer Image Version

armory/terraformer:2026.07.13.08.57.58.release-2.40.x

### Service VCS

[5316cdf53a2c78f78c116ff478012d58f9974e27](https://github.com/armory-io/armory-extensions/commit/5316cdf53a2c78f78c116ff478012d58f9974e27)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:fdc8ca2fc7b96b89a1d39f61c550739115286ddb8a6f39433f2280d177a21e7b",
        "repository": "armory/terraformer",
        "tag": "2026.07.13.08.57.58.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "5316cdf53a2c78f78c116ff478012d58f9974e27"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:fdc8ca2fc7b96b89a1d39f61c550739115286ddb8a6f39433f2280d177a21e7b",
        "repository": "armory/terraformer",
        "tag": "2026.07.13.08.57.58.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "5316cdf53a2c78f78c116ff478012d58f9974e27"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```