### PR TITLE
chore(cd): update terraformer version to 2026.07.14.11.50.08.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:fdc8ca2fc7b96b89a1d39f61c550739115286ddb8a6f39433f2280d177a21e7b
+      imageId: sha256:f54b56a7fc8cf4f139b8d5616500dc607479d3b55552981bfc7835096e0c5675
       repository: armory/terraformer
-      tag: 2026.07.13.08.57.58.release-2.40.x
+      tag: 2026.07.14.11.50.08.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 5316cdf53a2c78f78c116ff478012d58f9974e27
+      sha: 10e85095a1b1d2b9bd3389a560ff3604f0833096


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.40.x**

### terraformer Image Version

armory/terraformer:2026.07.14.11.50.08.release-2.40.x

### Service VCS

[10e85095a1b1d2b9bd3389a560ff3604f0833096](https://github.com/armory-io/armory-extensions/commit/10e85095a1b1d2b9bd3389a560ff3604f0833096)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:f54b56a7fc8cf4f139b8d5616500dc607479d3b55552981bfc7835096e0c5675",
        "repository": "armory/terraformer",
        "tag": "2026.07.14.11.50.08.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "10e85095a1b1d2b9bd3389a560ff3604f0833096"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:f54b56a7fc8cf4f139b8d5616500dc607479d3b55552981bfc7835096e0c5675",
        "repository": "armory/terraformer",
        "tag": "2026.07.14.11.50.08.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "10e85095a1b1d2b9bd3389a560ff3604f0833096"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```