### PR TITLE
chore(cd): update front50-armory version to 2026.07.14.12.17.22.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:830af38b5118afa30513d5b1b39b7a0ac19bd19957cc6057155afd43b67ae99d
+      imageId: sha256:f1e64e84b543bb67e6ebaa94cebb485d319eae0eb06a3324f514025b93c6c473
       repository: armory/front50-armory
-      tag: 2026.07.13.08.57.58.release-2.40.x
+      tag: 2026.07.14.12.17.22.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 5316cdf53a2c78f78c116ff478012d58f9974e27
+      sha: 35532b4a79ae36d7fcc48f8fadd75f0cc104d9a9
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.40.x**

### front50-armory Image Version

armory/front50-armory:2026.07.14.12.17.22.release-2.40.x

### Service VCS

[35532b4a79ae36d7fcc48f8fadd75f0cc104d9a9](https://github.com/armory-io/armory-extensions/commit/35532b4a79ae36d7fcc48f8fadd75f0cc104d9a9)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:f1e64e84b543bb67e6ebaa94cebb485d319eae0eb06a3324f514025b93c6c473",
        "repository": "armory/front50-armory",
        "tag": "2026.07.14.12.17.22.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "35532b4a79ae36d7fcc48f8fadd75f0cc104d9a9"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:f1e64e84b543bb67e6ebaa94cebb485d319eae0eb06a3324f514025b93c6c473",
        "repository": "armory/front50-armory",
        "tag": "2026.07.14.12.17.22.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "35532b4a79ae36d7fcc48f8fadd75f0cc104d9a9"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```