### PR TITLE
chore(cd): update front50-armory version to 2026.07.15.13.33.43.release-2.39.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:44070be9fc26534df29d9603dae9624288bd81c767824fa9074e792ff3c23174
+      imageId: sha256:75923d300f14d2fef156d4be513dee5ba36f8acdc79364ee1ee970e893a47b75
       repository: armory/front50-armory
-      tag: 2026.06.19.14.17.46.release-2.39.x
+      tag: 2026.07.15.13.33.43.release-2.39.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 8f40c99bd0979c73db2c003b9dccc00dd960551b
+      sha: bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.39.x**

### front50-armory Image Version

armory/front50-armory:2026.07.15.13.33.43.release-2.39.x

### Service VCS

[bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9](https://github.com/armory-io/armory-extensions/commit/bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.39.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:75923d300f14d2fef156d4be513dee5ba36f8acdc79364ee1ee970e893a47b75",
        "repository": "armory/front50-armory",
        "tag": "2026.07.15.13.33.43.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:75923d300f14d2fef156d4be513dee5ba36f8acdc79364ee1ee970e893a47b75",
        "repository": "armory/front50-armory",
        "tag": "2026.07.15.13.33.43.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```