### PR TITLE
chore(cd): update gate-armory version to 2026.07.15.13.33.43.release-2.39.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:fa109d3758b67faaf57813bc7dd20f108414601e2edf0b0baf34521650dba4f5
+      imageId: sha256:007f38f10410833702c2f368891698fd06d0c9a1f7e29efcf08cf613dc17c81b
       repository: armory/gate-armory
-      tag: 2026.06.19.14.17.46.release-2.39.x
+      tag: 2026.07.15.13.33.43.release-2.39.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 8f40c99bd0979c73db2c003b9dccc00dd960551b
+      sha: bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.39.x**

### gate-armory Image Version

armory/gate-armory:2026.07.15.13.33.43.release-2.39.x

### Service VCS

[bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9](https://github.com/armory-io/armory-extensions/commit/bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.39.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:007f38f10410833702c2f368891698fd06d0c9a1f7e29efcf08cf613dc17c81b",
        "repository": "armory/gate-armory",
        "tag": "2026.07.15.13.33.43.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:007f38f10410833702c2f368891698fd06d0c9a1f7e29efcf08cf613dc17c81b",
        "repository": "armory/gate-armory",
        "tag": "2026.07.15.13.33.43.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```