### PR TITLE
chore(cd): update clouddriver-armory version to 2026.07.15.13.33.43.release-2.39.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:65f48275dbc381dc47578706cd4cd6701de17c75936bdc451cc1b5bb5d29975f
+      imageId: sha256:8a85065aa7d7567dfd7c7fdf792400a720682b3a4304668baec19759948fddf3
       repository: armory/clouddriver-armory
-      tag: 2026.06.19.14.17.46.release-2.39.x
+      tag: 2026.07.15.13.33.43.release-2.39.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 8f40c99bd0979c73db2c003b9dccc00dd960551b
+      sha: bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.39.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.07.15.13.33.43.release-2.39.x

### Service VCS

[bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9](https://github.com/armory-io/armory-extensions/commit/bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.39.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8a85065aa7d7567dfd7c7fdf792400a720682b3a4304668baec19759948fddf3",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.15.13.33.43.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:8a85065aa7d7567dfd7c7fdf792400a720682b3a4304668baec19759948fddf3",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.15.13.33.43.release-2.39.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "bfadc96c0bbc3a3ebeea286f8b8c9781a7d8a6a9"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```