### PR TITLE
chore(cd): update dinghy version to 2026.07.24.13.50.08.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -26,15 +26,15 @@ services:
   dinghy:
     baseService: dinghy
     image:
-      imageId: sha256:b279930094f7350113688b89950d45e683a8a81634d4e6e0bbd8e64bbf064894
+      imageId: sha256:093e4eac07d739529115b24c74a0ce4ce0ca86db9f821173a352ace901d1710b
       repository: armory/dinghy
-      tag: 2026.07.23.13.34.15.release-2.40.x
+      tag: 2026.07.24.13.50.08.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 785162a8b8c73feab6127077c23b667f192f457c
+      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
   echo-armory:
     baseService: echo
     image:


### PR DESCRIPTION
## Promotion Of New dinghy Version

### Release Branch

* **release-2.40.x**

### dinghy Image Version

armory/dinghy:2026.07.24.13.50.08.release-2.40.x

### Service VCS

[6e605c0756d2286bed4b85326b084af6e8ab8c20](https://github.com/armory-io/armory-extensions/commit/6e605c0756d2286bed4b85326b084af6e8ab8c20)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "dinghy",
      "image": {
        "imageId": "sha256:093e4eac07d739529115b24c74a0ce4ce0ca86db9f821173a352ace901d1710b",
        "repository": "armory/dinghy",
        "tag": "2026.07.24.13.50.08.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "6e605c0756d2286bed4b85326b084af6e8ab8c20"
      }
    },
    "name": "dinghy"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "dinghy",
      "image": {
        "imageId": "sha256:093e4eac07d739529115b24c74a0ce4ce0ca86db9f821173a352ace901d1710b",
        "repository": "armory/dinghy",
        "tag": "2026.07.24.13.50.08.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "6e605c0756d2286bed4b85326b084af6e8ab8c20"
      }
    },
    "name": "dinghy"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```