### PR TITLE
chore(cd): update clouddriver-armory version to 2026.07.24.13.50.08.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:e97b091e1f14df819c8eb6296be27d53a7611d212c5025f42eae48a9df2f435b
+      imageId: sha256:3fee12539f66e2039c56cce1bdcfc222bcb1aed28fce770f4b963411a534e560
       repository: armory/clouddriver-armory
-      tag: 2026.07.15.08.54.01.release-2.40.x
+      tag: 2026.07.24.13.50.08.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: e099cb401ee08c956cd23ff1871e2d403263f479
+      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.40.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.07.24.13.50.08.release-2.40.x

### Service VCS

[6e605c0756d2286bed4b85326b084af6e8ab8c20](https://github.com/armory-io/armory-extensions/commit/6e605c0756d2286bed4b85326b084af6e8ab8c20)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3fee12539f66e2039c56cce1bdcfc222bcb1aed28fce770f4b963411a534e560",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.24.13.50.08.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "6e605c0756d2286bed4b85326b084af6e8ab8c20"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:3fee12539f66e2039c56cce1bdcfc222bcb1aed28fce770f4b963411a534e560",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.07.24.13.50.08.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "6e605c0756d2286bed4b85326b084af6e8ab8c20"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```