### PR TITLE
chore(cd): update terraformer version to 2026.07.28.14.24.20.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:e079006d64776ff993882463fd1950a1281647995d3bc30aed2c1d532e3621b8
+      imageId: sha256:3ce8e96a8dd0c8f205fbe30fe675c6c8bddb10f65cde6206a04f65b070109e0e
       repository: armory/terraformer
-      tag: 2025.08.20.02.33.17.main
+      tag: 2026.07.28.14.24.20.main
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: babaa4704f1df8a6f6b42e533716396c8a0f529b
+      sha: 789d7eaeb20ddd2544efad606ce885ff1424d34d


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **master**

### terraformer Image Version

armory/terraformer:2026.07.28.14.24.20.main

### Service VCS

[789d7eaeb20ddd2544efad606ce885ff1424d34d](https://github.com/armory-io/armory-extensions/commit/789d7eaeb20ddd2544efad606ce885ff1424d34d)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:3ce8e96a8dd0c8f205fbe30fe675c6c8bddb10f65cde6206a04f65b070109e0e",
        "repository": "armory/terraformer",
        "tag": "2026.07.28.14.24.20.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "789d7eaeb20ddd2544efad606ce885ff1424d34d"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:3ce8e96a8dd0c8f205fbe30fe675c6c8bddb10f65cde6206a04f65b070109e0e",
        "repository": "armory/terraformer",
        "tag": "2026.07.28.14.24.20.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "789d7eaeb20ddd2544efad606ce885ff1424d34d"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```