### PR TITLE
chore(cd): update front50-armory version to 2026.07.31.14.58.31.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:3cb9658826d2d21489dc2e0c24cda3dc7c7c56ddb97a9cfa878f6aa03841fa79
+      imageId: sha256:fc1099ee62f93833a196ca43936935543bd87a3ae90098e18f125c2a46b023b8
       repository: armory/front50-armory
-      tag: 2026.07.24.13.50.08.release-2.40.x
+      tag: 2026.07.31.14.58.31.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
+      sha: f2c298d1da0f04d8753000d015aa912a16553de6
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.40.x**

### front50-armory Image Version

armory/front50-armory:2026.07.31.14.58.31.release-2.40.x

### Service VCS

[f2c298d1da0f04d8753000d015aa912a16553de6](https://github.com/armory-io/armory-extensions/commit/f2c298d1da0f04d8753000d015aa912a16553de6)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:fc1099ee62f93833a196ca43936935543bd87a3ae90098e18f125c2a46b023b8",
        "repository": "armory/front50-armory",
        "tag": "2026.07.31.14.58.31.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "f2c298d1da0f04d8753000d015aa912a16553de6"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:fc1099ee62f93833a196ca43936935543bd87a3ae90098e18f125c2a46b023b8",
        "repository": "armory/front50-armory",
        "tag": "2026.07.31.14.58.31.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "f2c298d1da0f04d8753000d015aa912a16553de6"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```