### PR TITLE
chore(cd): update gate-armory version to 2026.07.31.14.58.31.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:62d57aa63670e07d71896325421538a1d01298654922d464843874f1d40de509
+      imageId: sha256:dfe0c8355da11bd7be7b3d7590b91f7355086399b377ec563ed4de04ea15cdb1
       repository: armory/gate-armory
-      tag: 2026.07.24.13.50.08.release-2.40.x
+      tag: 2026.07.31.14.58.31.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
+      sha: f2c298d1da0f04d8753000d015aa912a16553de6
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.07.31.14.58.31.release-2.40.x

### Service VCS

[f2c298d1da0f04d8753000d015aa912a16553de6](https://github.com/armory-io/armory-extensions/commit/f2c298d1da0f04d8753000d015aa912a16553de6)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:dfe0c8355da11bd7be7b3d7590b91f7355086399b377ec563ed4de04ea15cdb1",
        "repository": "armory/gate-armory",
        "tag": "2026.07.31.14.58.31.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "f2c298d1da0f04d8753000d015aa912a16553de6"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:dfe0c8355da11bd7be7b3d7590b91f7355086399b377ec563ed4de04ea15cdb1",
        "repository": "armory/gate-armory",
        "tag": "2026.07.31.14.58.31.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "f2c298d1da0f04d8753000d015aa912a16553de6"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```