### PR TITLE
chore(cd): update front50-armory version to 2026.08.05.15.58.28.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:3cb9658826d2d21489dc2e0c24cda3dc7c7c56ddb97a9cfa878f6aa03841fa79
+      imageId: sha256:7795112ed4940e8d263bd945156b97196b6090bbc409d0bbe0d1ad32def5f07d
       repository: armory/front50-armory
-      tag: 2026.07.24.13.50.08.release-2.40.x
+      tag: 2026.08.05.15.58.28.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
+      sha: 9d0a0abba407b8e2a3fbae6d0326712233c2572c
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.40.x**

### front50-armory Image Version

armory/front50-armory:2026.08.05.15.58.28.release-2.40.x

### Service VCS

[9d0a0abba407b8e2a3fbae6d0326712233c2572c](https://github.com/armory-io/armory-extensions/commit/9d0a0abba407b8e2a3fbae6d0326712233c2572c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:7795112ed4940e8d263bd945156b97196b6090bbc409d0bbe0d1ad32def5f07d",
        "repository": "armory/front50-armory",
        "tag": "2026.08.05.15.58.28.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9d0a0abba407b8e2a3fbae6d0326712233c2572c"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:7795112ed4940e8d263bd945156b97196b6090bbc409d0bbe0d1ad32def5f07d",
        "repository": "armory/front50-armory",
        "tag": "2026.08.05.15.58.28.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9d0a0abba407b8e2a3fbae6d0326712233c2572c"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```