### PR TITLE
chore(cd): update gate-armory version to 2026.08.05.15.58.28.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:62d57aa63670e07d71896325421538a1d01298654922d464843874f1d40de509
+      imageId: sha256:ddf61f5b2a05d997c10263ca4c70d926066688a790c45345821d9a0bc0ef3711
       repository: armory/gate-armory
-      tag: 2026.07.24.13.50.08.release-2.40.x
+      tag: 2026.08.05.15.58.28.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
+      sha: 9d0a0abba407b8e2a3fbae6d0326712233c2572c
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.08.05.15.58.28.release-2.40.x

### Service VCS

[9d0a0abba407b8e2a3fbae6d0326712233c2572c](https://github.com/armory-io/armory-extensions/commit/9d0a0abba407b8e2a3fbae6d0326712233c2572c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:ddf61f5b2a05d997c10263ca4c70d926066688a790c45345821d9a0bc0ef3711",
        "repository": "armory/gate-armory",
        "tag": "2026.08.05.15.58.28.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9d0a0abba407b8e2a3fbae6d0326712233c2572c"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:ddf61f5b2a05d997c10263ca4c70d926066688a790c45345821d9a0bc0ef3711",
        "repository": "armory/gate-armory",
        "tag": "2026.08.05.15.58.28.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9d0a0abba407b8e2a3fbae6d0326712233c2572c"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```