### PR TITLE
chore(cd): update terraformer version to 2026.08.05.15.58.28.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:f2e9157109d963e2b285793d84f175ec038055a2f088f5b3708ec35d07ae1c7a
+      imageId: sha256:fca5bd5b63fa88b0b50c9f33d6cea589f6d47c432a0727c649d57550ab78bce5
       repository: armory/terraformer
-      tag: 2026.07.24.13.50.08.release-2.40.x
+      tag: 2026.08.05.15.58.28.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
+      sha: 9d0a0abba407b8e2a3fbae6d0326712233c2572c


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.40.x**

### terraformer Image Version

armory/terraformer:2026.08.05.15.58.28.release-2.40.x

### Service VCS

[9d0a0abba407b8e2a3fbae6d0326712233c2572c](https://github.com/armory-io/armory-extensions/commit/9d0a0abba407b8e2a3fbae6d0326712233c2572c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:fca5bd5b63fa88b0b50c9f33d6cea589f6d47c432a0727c649d57550ab78bce5",
        "repository": "armory/terraformer",
        "tag": "2026.08.05.15.58.28.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9d0a0abba407b8e2a3fbae6d0326712233c2572c"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:fca5bd5b63fa88b0b50c9f33d6cea589f6d47c432a0727c649d57550ab78bce5",
        "repository": "armory/terraformer",
        "tag": "2026.08.05.15.58.28.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "9d0a0abba407b8e2a3fbae6d0326712233c2572c"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```