### PR TITLE
chore(cd): update front50-armory version to 2026.08.10.12.17.22.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:3cb9658826d2d21489dc2e0c24cda3dc7c7c56ddb97a9cfa878f6aa03841fa79
+      imageId: sha256:b8d0d1f2b0e47d706fa71c6a3f4649a9f1cc5e73308c2f725afc0e03ae2b90c6
       repository: armory/front50-armory
-      tag: 2026.07.24.13.50.08.release-2.40.x
+      tag: 2026.08.10.12.17.22.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 6e605c0756d2286bed4b85326b084af6e8ab8c20
+      sha: aa5e23061f7d288bfc347ca81a1826abcf23fbda
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **release-2.40.x**

### front50-armory Image Version

armory/front50-armory:2026.08.10.12.17.22.release-2.40.x

### Service VCS

[aa5e23061f7d288bfc347ca81a1826abcf23fbda](https://github.com/armory-io/armory-extensions/commit/aa5e23061f7d288bfc347ca81a1826abcf23fbda)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:b8d0d1f2b0e47d706fa71c6a3f4649a9f1cc5e73308c2f725afc0e03ae2b90c6",
        "repository": "armory/front50-armory",
        "tag": "2026.08.10.12.17.22.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "aa5e23061f7d288bfc347ca81a1826abcf23fbda"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:b8d0d1f2b0e47d706fa71c6a3f4649a9f1cc5e73308c2f725afc0e03ae2b90c6",
        "repository": "armory/front50-armory",
        "tag": "2026.08.10.12.17.22.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "aa5e23061f7d288bfc347ca81a1826abcf23fbda"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```