### PR TITLE
chore(cd): update gate-armory version to 2026.08.11.12.09.59.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -74,15 +74,15 @@ services:
   gate-armory:
     baseService: gate
     image:
-      imageId: sha256:f4d1fa737d36107763cb31a5b27de60313d48fd4552beb75fd6e6bd5b2240f34
+      imageId: sha256:611597136b8ec45358d9ad57ce356b06349f14ed6ddb834af5969ec6d0719583
       repository: armory/gate-armory
-      tag: 2026.08.10.12.17.22.release-2.40.x
+      tag: 2026.08.11.12.09.59.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: aa5e23061f7d288bfc347ca81a1826abcf23fbda
+      sha: 52feda30d3647f09f7366fa4a9ce4fb0f634009c
   igor-armory:
     baseService: igor
     image:


### PR DESCRIPTION
## Promotion Of New gate-armory Version

### Release Branch

* **release-2.40.x**

### gate-armory Image Version

armory/gate-armory:2026.08.11.12.09.59.release-2.40.x

### Service VCS

[52feda30d3647f09f7366fa4a9ce4fb0f634009c](https://github.com/armory-io/armory-extensions/commit/52feda30d3647f09f7366fa4a9ce4fb0f634009c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:611597136b8ec45358d9ad57ce356b06349f14ed6ddb834af5969ec6d0719583",
        "repository": "armory/gate-armory",
        "tag": "2026.08.11.12.09.59.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "52feda30d3647f09f7366fa4a9ce4fb0f634009c"
      }
    },
    "name": "gate-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "gate",
      "image": {
        "imageId": "sha256:611597136b8ec45358d9ad57ce356b06349f14ed6ddb834af5969ec6d0719583",
        "repository": "armory/gate-armory",
        "tag": "2026.08.11.12.09.59.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "52feda30d3647f09f7366fa4a9ce4fb0f634009c"
      }
    },
    "name": "gate-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```