### PR TITLE
chore(cd): update terraformer version to 2026.08.11.12.09.59.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -134,12 +134,12 @@ services:
   terraformer:
     baseService: terraformer
     image:
-      imageId: sha256:a231be9229c38e8944b6778c462feec6683f233870c036e3695805d7d205b1cf
+      imageId: sha256:c3d612969a68785ae5204a0cb7cd5fd92972fc7bf6391e4092bc77941875b439
       repository: armory/terraformer
-      tag: 2026.08.10.12.17.22.release-2.40.x
+      tag: 2026.08.11.12.09.59.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: aa5e23061f7d288bfc347ca81a1826abcf23fbda
+      sha: 52feda30d3647f09f7366fa4a9ce4fb0f634009c


### PR DESCRIPTION
## Promotion Of New terraformer Version

### Release Branch

* **release-2.40.x**

### terraformer Image Version

armory/terraformer:2026.08.11.12.09.59.release-2.40.x

### Service VCS

[52feda30d3647f09f7366fa4a9ce4fb0f634009c](https://github.com/armory-io/armory-extensions/commit/52feda30d3647f09f7366fa4a9ce4fb0f634009c)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:c3d612969a68785ae5204a0cb7cd5fd92972fc7bf6391e4092bc77941875b439",
        "repository": "armory/terraformer",
        "tag": "2026.08.11.12.09.59.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "52feda30d3647f09f7366fa4a9ce4fb0f634009c"
      }
    },
    "name": "terraformer"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "terraformer",
      "image": {
        "imageId": "sha256:c3d612969a68785ae5204a0cb7cd5fd92972fc7bf6391e4092bc77941875b439",
        "repository": "armory/terraformer",
        "tag": "2026.08.11.12.09.59.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "52feda30d3647f09f7366fa4a9ce4fb0f634009c"
      }
    },
    "name": "terraformer"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```