### PR TITLE
chore(cd): update clouddriver-armory version to 2026.08.20.12.17.14.release-2.40.x

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -2,15 +2,15 @@ services:
   clouddriver-armory:
     baseService: clouddriver
     image:
-      imageId: sha256:0d421f38d30d2c8fd3b6244a071324afc242214baaa98ed5b90936b91e938f83
+      imageId: sha256:f2ba53858b693c18c11e642f35f09786f763e53ecfb8eda652aa0265e2546597
       repository: armory/clouddriver-armory
-      tag: 2026.08.11.12.09.59.release-2.40.x
+      tag: 2026.08.20.12.17.14.release-2.40.x
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: 52feda30d3647f09f7366fa4a9ce4fb0f634009c
+      sha: 0793dbe8105fd4df548d1e7820fd1560bfc69d8e
   deck-armory:
     baseService: deck
     image:


### PR DESCRIPTION
## Promotion Of New clouddriver-armory Version

### Release Branch

* **release-2.40.x**

### clouddriver-armory Image Version

armory/clouddriver-armory:2026.08.20.12.17.14.release-2.40.x

### Service VCS

[0793dbe8105fd4df548d1e7820fd1560bfc69d8e](https://github.com/armory-io/armory-extensions/commit/0793dbe8105fd4df548d1e7820fd1560bfc69d8e)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "release-2.40.x",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:f2ba53858b693c18c11e642f35f09786f763e53ecfb8eda652aa0265e2546597",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.08.20.12.17.14.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "0793dbe8105fd4df548d1e7820fd1560bfc69d8e"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "clouddriver",
      "image": {
        "imageId": "sha256:f2ba53858b693c18c11e642f35f09786f763e53ecfb8eda652aa0265e2546597",
        "repository": "armory/clouddriver-armory",
        "tag": "2026.08.20.12.17.14.release-2.40.x"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "0793dbe8105fd4df548d1e7820fd1560bfc69d8e"
      }
    },
    "name": "clouddriver-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```