### PR TITLE
chore(cd): update front50-armory version to 2026.08.21.17.38.36.main

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -62,15 +62,15 @@ services:
   front50-armory:
     baseService: front50
     image:
-      imageId: sha256:01b6f9cfe4050bc26490dc5618aec9c29725b18bab7a9c189c44593a73020147
+      imageId: sha256:209ac0069245e7916860ab2f4f3dd590f19103687b3431df5792a183926ac69f
       repository: armory/front50-armory
-      tag: 2026.08.13.13.56.45.main
+      tag: 2026.08.21.17.38.36.main
     vcs:
       repo:
         orgName: armory-io
         repoName: armory-extensions
         type: github
-      sha: a5fa7cb0ec92217c788707301b86cd6e668b7471
+      sha: a49436f339049248cb3106df8d3f2963741213b0
   gate-armory:
     baseService: gate
     image:


### PR DESCRIPTION
## Promotion Of New front50-armory Version

### Release Branch

* **master**

### front50-armory Image Version

armory/front50-armory:2026.08.21.17.38.36.main

### Service VCS

[a49436f339049248cb3106df8d3f2963741213b0](https://github.com/armory-io/armory-extensions/commit/a49436f339049248cb3106df8d3f2963741213b0)

### Base Service VCS

[](https://github.com/spinnaker/spinnaker/commit/)

Event Payload
```
{
  "branch": "master",
  "service": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:209ac0069245e7916860ab2f4f3dd590f19103687b3431df5792a183926ac69f",
        "repository": "armory/front50-armory",
        "tag": "2026.08.21.17.38.36.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a49436f339049248cb3106df8d3f2963741213b0"
      }
    },
    "name": "front50-armory"
  },
  "stackEntry": {
    "baseVcs": {
      "repo": {
        "orgName": "spinnaker",
        "repoName": "spinnaker",
        "type": "github"
      },
      "sha": ""
    },
    "details": {
      "baseService": "front50",
      "image": {
        "imageId": "sha256:209ac0069245e7916860ab2f4f3dd590f19103687b3431df5792a183926ac69f",
        "repository": "armory/front50-armory",
        "tag": "2026.08.21.17.38.36.main"
      },
      "vcs": {
        "repo": {
          "orgName": "armory-io",
          "repoName": "armory-extensions",
          "type": "github"
        },
        "sha": "a49436f339049248cb3106df8d3f2963741213b0"
      }
    },
    "name": "front50-armory"
  },
  "stackFile": "stack.yml",
  "stackPath": "services"
}
```